### PR TITLE
device-list: show shared devices by default

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -153,7 +153,7 @@ func (a *Api) Delete(url string, data []byte) (*[]byte, error) {
 }
 
 func (a *Api) DeviceList() (*DeviceList, error) {
-	return a.DeviceListCont(a.serverUrl + "/ota/devices/")
+	return a.DeviceListCont(a.serverUrl + "/ota/devices/?shared=1")
 }
 
 func (a *Api) DeviceListCont(url string) (*DeviceList, error) {


### PR DESCRIPTION
Currently, only the token owner's devices are shown by "device list".
Instead, let's show all devices attached to the owner's org(s) by
specifying ?shared=1 on the API call.

Signed-off-by: Michael Scott <mike@foundries.io>