### PR TITLE
Add Support for new "device update" events

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -26,17 +26,19 @@ type NetInfo struct {
 }
 
 type Device struct {
-	Uuid       string   `json:"uuid"`
-	Name       string   `json:"name"`
-	Owner      string   `json:"owner"`
-	Factory    string   `json:"factory"`
-	CreatedAt  string   `json:"created-at"`
-	LastSeen   string   `json:"last-seen"`
-	OstreeHash string   `json:"ostree-hash"`
-	DockerApps []string `json:"docker-apps,omitempty"`
-	Tags       []string `json:"device-tags,omitempty"`
-	Network    *NetInfo `json:"network-info,omitempty"`
-	TargetName string   `json:"target-name"`
+	Uuid          string   `json:"uuid"`
+	Name          string   `json:"name"`
+	Owner         string   `json:"owner"`
+	Factory       string   `json:"factory"`
+	CreatedAt     string   `json:"created-at"`
+	LastSeen      string   `json:"last-seen"`
+	OstreeHash    string   `json:"ostree-hash"`
+	DockerApps    []string `json:"docker-apps,omitempty"`
+	Tags          []string `json:"device-tags,omitempty"`
+	Network       *NetInfo `json:"network-info,omitempty"`
+	TargetName    string   `json:"target-name"`
+	Status        string   `json:"status"`
+	CurrentUpdate string   `json:"current-update"`
 }
 
 type DeviceList struct {

--- a/client/foundries.go
+++ b/client/foundries.go
@@ -32,6 +32,22 @@ type Update struct {
 	Time          string `json:"time"`
 }
 
+type EventType struct {
+	Id string `json:"id"`
+}
+
+type EventDetail struct {
+	Version    string `json:"version"`
+	TargetName string `json:"targetName"`
+	Success    *bool  `json:"success,omitempty"`
+}
+
+type UpdateEvent struct {
+	Time   string      `json:"deviceTime"`
+	Type   EventType   `json:"eventType"`
+	Detail EventDetail `json:"event"`
+}
+
 type Device struct {
 	Uuid          string   `json:"uuid"`
 	Name          string   `json:"name"`
@@ -171,7 +187,7 @@ func (a *Api) Delete(url string, data []byte) (*[]byte, error) {
 }
 
 func (a *Api) DeviceGet(device string) (*Device, error) {
-	body, err := a.Get(a.serverUrl+"/ota/devices/"+device+"/")
+	body, err := a.Get(a.serverUrl + "/ota/devices/" + device + "/")
 	d := Device{}
 	err = json.Unmarshal(*body, &d)
 	if err != nil {
@@ -206,6 +222,16 @@ func (a *Api) DeviceDelete(device string) error {
 	bytes := []byte{}
 	_, err := a.Delete(a.serverUrl+"/ota/devices/"+device+"/", bytes)
 	return err
+}
+
+func (a *Api) DeviceUpdateEvents(device, correlationId string) ([]UpdateEvent, error) {
+	body, err := a.Get(a.serverUrl + "/ota/devices/" + device + "/updates/" + correlationId + "/")
+	var events []UpdateEvent
+	err = json.Unmarshal(*body, &events)
+	if err != nil {
+		return events, err
+	}
+	return events, nil
 }
 
 func (a *Api) TargetsListRaw(factory string) (*[]byte, error) {

--- a/client/foundries.go
+++ b/client/foundries.go
@@ -25,6 +25,13 @@ type NetInfo struct {
 	MAC      string `json:"mac"`
 }
 
+type Update struct {
+	CorrelationId string `json:"correlation-id"`
+	Target        string `json:"target"`
+	Version       string `json:"version"`
+	Time          string `json:"time"`
+}
+
 type Device struct {
 	Uuid          string   `json:"uuid"`
 	Name          string   `json:"name"`
@@ -39,6 +46,7 @@ type Device struct {
 	TargetName    string   `json:"target-name"`
 	Status        string   `json:"status"`
 	CurrentUpdate string   `json:"current-update"`
+	Updates       []Update `json:"updates"`
 }
 
 type DeviceList struct {
@@ -160,6 +168,16 @@ func (a *Api) Delete(url string, data []byte) (*[]byte, error) {
 		return nil, fmt.Errorf("Unable to DELETE '%s': HTTP_%d\n=%s", url, res.StatusCode, body)
 	}
 	return &body, nil
+}
+
+func (a *Api) DeviceGet(device string) (*Device, error) {
+	body, err := a.Get(a.serverUrl+"/ota/devices/"+device+"/")
+	d := Device{}
+	err = json.Unmarshal(*body, &d)
+	if err != nil {
+		return nil, err
+	}
+	return &d, nil
 }
 
 func (a *Api) DeviceList(shared bool) (*DeviceList, error) {

--- a/cmd/device_list.go
+++ b/cmd/device_list.go
@@ -85,6 +85,12 @@ func doDeviceList(cmd *cobra.Command, args []string) {
 			if len(device.DockerApps) > 0 {
 				fmt.Printf("\tDocker Apps:\t%s\n", strings.Join(device.DockerApps, ","))
 			}
+			if len(device.Status) > 0 {
+				fmt.Printf("\tStatus:\t\t%s\n", device.Status)
+			}
+			if len(device.CurrentUpdate) > 0 {
+				fmt.Printf("\tUpdate Id:\t%s\n", device.CurrentUpdate)
+			}
 		}
 	}
 }

--- a/cmd/device_show.go
+++ b/cmd/device_show.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var deviceShowCmd = &cobra.Command{
+	Use:   "show [name]",
+	Short: "Show details of a specific device",
+	Run:   doDeviceShow,
+	Args:  cobra.ExactArgs(1),
+}
+
+func init() {
+	deviceCmd.AddCommand(deviceShowCmd)
+}
+
+func doDeviceShow(cmd *cobra.Command, args []string) {
+	logrus.Debug("Showing device")
+	device, err := api.DeviceGet(args[0])
+	if err != nil {
+		fmt.Print("ERROR: ")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fmt.Printf("\tUUID:\t\t%s\n", device.Uuid)
+	fmt.Printf("\tOwner:\t\t%s\n", device.Owner)
+	fmt.Printf("\tFactory:\t%s\n", device.Factory)
+	fmt.Printf("\tTarget:\t\t%s / sha256(%s)\n", device.TargetName, device.OstreeHash)
+	fmt.Printf("\tOstree Hash:\t%s\n", device.OstreeHash)
+	fmt.Printf("\tCreated:\t%s\n", device.CreatedAt)
+	fmt.Printf("\tLast Seen:\t%s\n", device.LastSeen)
+	if len(device.Tags) > 0 {
+		fmt.Printf("\tTags:\t\t%s\n", strings.Join(device.Tags, ","))
+	}
+	if len(device.DockerApps) > 0 {
+		fmt.Printf("\tDocker Apps:\t%s\n", strings.Join(device.DockerApps, ","))
+	}
+	if len(device.Status) > 0 {
+		fmt.Printf("\tStatus:\t\t%s\n", device.Status)
+	}
+	if len(device.CurrentUpdate) > 0 {
+		fmt.Printf("\tUpdate Id:\t%s\n", device.CurrentUpdate)
+	}
+	if len(device.Updates) > 0 {
+		fmt.Printf("\tUpdate History:\n")
+		for idx, update := range device.Updates {
+			if idx > 0 {
+				fmt.Printf("\t\t-------------------------------------------------\n\n")
+			}
+			fmt.Printf("\t\tId:      %s\n", update.CorrelationId)
+			fmt.Printf("\t\tTime:    %s\n", update.Time)
+			fmt.Printf("\t\tTarget:  %s\n", update.Target)
+			fmt.Printf("\t\tVersion: %s\n", update.Version)
+		}
+	}
+}

--- a/cmd/device_show_update.go
+++ b/cmd/device_show_update.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var deviceShowUpdateCmd = &cobra.Command{
+	Use:   "show-update [name] [update-id]",
+	Short: "Show details of a specific device update",
+	Run:   doDeviceShowUpdate,
+	Args:  cobra.ExactArgs(2),
+}
+
+func init() {
+	deviceCmd.AddCommand(deviceShowUpdateCmd)
+}
+
+func doDeviceShowUpdate(cmd *cobra.Command, args []string) {
+	logrus.Debug("Showing device update")
+	events, err := api.DeviceUpdateEvents(args[0], args[1])
+	if err != nil {
+		fmt.Print("ERROR: ")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	for _, event := range events {
+		fmt.Printf("%s : %s(%s)", event.Time, event.Type.Id, event.Detail.TargetName)
+		if event.Detail.Success != nil {
+			if *event.Detail.Success {
+				fmt.Println(" -> Succeed")
+			} else {
+				fmt.Println(" -> Failed!")
+			}
+		} else {
+			fmt.Println()
+		}
+	}
+}


### PR DESCRIPTION
The v51 version of aktualizr-lite include the ability to stream update events to the server:

 https://github.com/foundriesio/aktualizr/commit/e231d3b3d6d4377c6c3777683f0b70bfbcde649c

The ota-lite server now saves tthose events and exposes them through the REST API. This change updates fioctl to display this information.