### PR TITLE
Improve CLI output

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -80,6 +80,7 @@ type DeviceList struct {
 
 type DockerApp struct {
 	FileName string `json:"filename"`
+	Uri      string `json:"uri"`
 }
 
 type TufCustom struct {

--- a/cmd/targets_show.go
+++ b/cmd/targets_show.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cheynewallace/tabby"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/foundriesio/fioctl/client"
+)
+
+var targetShowCmd = &cobra.Command{
+	Use:   "show <version>",
+	Short: "Show details of a specific target.",
+	Run:   doTargetsShow,
+	Args:  cobra.ExactArgs(1),
+}
+
+func init() {
+	targetsCmd.AddCommand(targetShowCmd)
+}
+
+func doTargetsShow(cmd *cobra.Command, args []string) {
+	factory := viper.GetString("factory")
+	logrus.Debugf("Showing target for %s %s", factory, args[0])
+
+	targets, err := api.TargetsList(factory)
+	if err != nil {
+		fmt.Print("ERROR: ")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	hashes := make(map[string]string)
+	var tags []string
+	var apps map[string]client.DockerApp
+	for _, target := range targets.Signed.Targets {
+		custom, err := api.TargetCustom(target)
+		if err != nil {
+			fmt.Printf("ERROR: %s\n", err)
+			continue
+		}
+		if custom.Version != args[0] {
+			continue
+		}
+		if custom.TargetFormat != "OSTREE" {
+			logrus.Debugf("Skipping non-ostree target: %v", target)
+			continue
+		}
+		for _, hwid := range custom.HardwareIds {
+			hashes[hwid] = hex.EncodeToString(target.Hashes["sha256"])
+		}
+		apps = custom.DockerApps
+		tags = custom.Tags
+	}
+
+	fmt.Printf("Tags:\t%s\n\n", strings.Join(tags, ","))
+
+	t := tabby.New()
+	t.AddHeader("HARDWARE ID", "OSTREE HASH - SHA256")
+	for name, val := range hashes {
+		t.AddLine(name, val)
+	}
+	t.Print()
+
+	fmt.Println()
+
+	t = tabby.New()
+	t.AddHeader("DOCKER APP", "VERSION")
+	for name, app := range apps {
+		t.AddLine(name, app.FileName)
+	}
+	t.Print()
+}

--- a/cmd/targets_show.go
+++ b/cmd/targets_show.go
@@ -73,7 +73,11 @@ func doTargetsShow(cmd *cobra.Command, args []string) {
 	t = tabby.New()
 	t.AddHeader("DOCKER APP", "VERSION")
 	for name, app := range apps {
-		t.AddLine(name, app.FileName)
+		if len(app.FileName) > 0 {
+			t.AddLine(name, app.FileName)
+		} else {
+			t.AddLine(name, app.Uri)
+		}
 	}
 	t.Print()
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
+	github.com/cheynewallace/tabby v1.1.0
 	github.com/docker/go v1.5.1-1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/cheynewallace/tabby v1.1.0 h1:XtG/ZanoIvNZHfe0cClhWLzD/16GGF9UD7mMdWwYnCQ=
+github.com/cheynewallace/tabby v1.1.0/go.mod h1:Pba/6cUL8uYqvOc9RkyvFbHGrQ9wShyrn6/S/1OYVys=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=


### PR DESCRIPTION
This is a fairly big change to the way we display things. The intent is to make listing things easier to read. One side effect is that the listing doesn't always include as much information as it used to. However, the "show" versions of the commands should provide that detail when you need to drill down.

Here's an overview of the changes:

## fioctl device list-updates <device>
~~~
ID                                        TIME                  VERSION  TARGET
--                                        ----                  -------  ------
287-bbcb9b51-4b6b-42c4-9f65-b83b4c86bc09  2019-12-09T05:25:01Z  287      raspberrypi3-64-lmp-287
287-8c36f187-4eb5-440e-afa5-036b89f0997c  2019-12-09T05:21:54Z  287      raspberrypi3-64-lmp-287
....
~~~

## fioctl device list
~~~
NAME            FACTORY    TARGET                   STATUS   APPS
----            -------    ------                   ------   ----  
andy-test-1     secret     ???                      OK       
rpi3-1          andy-corp  raspberrypi3-64-lmp-287  OFFLINE  shellhttpd
test-for-tyler  andy-corp  ???                      OK   
~~~

## fioctl targets list -f limp --by-tag promoted
~~~
VERSION  TAGS                APPS                                       HARDWARE IDs
-------  ----                ----                                       ------------
622      postmerge,promoted                                             qemuarm64,qemuriscv64,cubox-i,beaglebone-yocto,raspberrypi3-64,apalis-imx6,colibri-imx7,cl-som-imx7,raspberrypi4,raspberrypi3,intel-corei7-64
633      postmerge,promoted                                             apalis-imx6,qemuarm64,cubox-i,raspberrypi3,intel-corei7-64,qemuriscv64,raspberrypi3-64,beaglebone-yocto,raspberrypi4,cl-som-imx7
716      postmerge,promoted  shellhttpd,x-kiosk,openthread-gateway      qemuarm64,raspberrypi4-64,qemuriscv64,beaglebone-yocto,intel-corei7-64,apalis-imx6,raspberrypi3-64,raspberrypi4,raspberrypi3
~~~
## fioctl targets show
Since the targets-list command shows so much less, a targets-show command is needed to help show the details of a target:
~~~
Tags:	devel

HARDWARE ID      OSTREE HASH - SHA256
-----------      --------------------
raspberrypi3-64  79cdb97fcdbbefad1cdfd77ce7769e75b776d1ff7d75aedcd7aef971fd1d6b56dd71d7f475ff766db6ba73ddbcd797fc

DOCKER APP  VERSION
----------  -------
fluentbit   fluentbit.dockerapp-282
shellhttpd  hub.foundries.io/andy-corp/shellhttpd@sha256:f6792eaca6ce97cb51c6154e60a28a55667a8cddb48d8e49c15d42cc8e3ffd36