### PR TITLE
Add login command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/*
+.vscode

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -11,4 +11,5 @@ var deviceCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(deviceCmd)
+	deviceCmd.PersistentFlags().StringP("token", "t", "", "API token from https://app.foundries.io/settings/tokens/")
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/foundriesio/fioctl/internal/oauth"
+)
+
+var loginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Access Foundries.io services with your client credentials",
+	Run:   doLogin,
+}
+
+func init() {
+	rootCmd.AddCommand(loginCmd)
+}
+
+func doLogin(cmd *cobra.Command, args []string) {
+	logrus.Debug("Executing login command")
+
+	var exitCode int
+
+	if cfg.ClientCredentials.ClientId == "" || cfg.ClientCredentials.ClientSecret == "" {
+		cfg.ReadClientCredentials()
+	}
+
+	if cfg.ClientCredentials.ClientId == "" || cfg.ClientCredentials.ClientSecret == "" {
+		fmt.Println("Cannot execute login without client ID or client secret.")
+		os.Exit(1)
+	}
+
+	cfg.Save(cfgFile)
+
+	oauthClient := oauth.GetClient(cfg)
+	expired, err := oauthClient.IsExpired()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if expired && oauthClient.HasRefreshToken() {
+		exitCode = oauthClient.Refresh()
+	} else if cfg.ClientCredentials.AccessToken == "" {
+		exitCode = oauthClient.Get()
+	} else {
+		fmt.Println("You are already logged in to Foundries.io services.")
+		os.Exit(0)
+	}
+
+	if exitCode == 0 {
+		cfg.Save(cfgFile)
+		fmt.Println("You are now logged in to Foundries.io services.")
+	}
+
+	os.Exit(exitCode)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,19 +2,22 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+	"path/filepath"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/foundriesio/fioctl/client"
+	"github.com/foundriesio/fioctl/internal/config"
 )
 
 var (
 	cfgFile string
 	api     *client.Api
+	cfg     *config.Config
 )
 
 var rootCmd = &cobra.Command{
@@ -48,14 +51,15 @@ func initConfig() {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
 	} else {
-		config, err := homedir.Expand("~/.config")
+		cfgDir, err := homedir.Expand("~/.config")
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
 
+		cfgFile = filepath.Join(cfgDir, "fioctl.yaml")
 		// Search config in home directory with name "fioctl" (without extension).
-		viper.AddConfigPath(config)
+		viper.AddConfigPath(cfgDir)
 		viper.SetConfigName("fioctl")
 	}
 
@@ -73,4 +77,5 @@ func initConfig() {
 	}
 
 	api = client.NewApiClient("https://api.foundries.io", viper.GetString("token"))
+	cfg = config.Load(cfgFile)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,8 +38,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.config/fioctl.yaml)")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Print verbose logging")
 
-	rootCmd.PersistentFlags().StringP("token", "t", "", "API token from https://app.foundries.io/settings/tokens/")
-
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/targets.go
+++ b/cmd/targets.go
@@ -15,6 +15,7 @@ var targetsCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(targetsCmd)
+	targetsCmd.PersistentFlags().StringP("token", "t", "", "API token from https://app.foundries.io/settings/tokens/")
 	targetsCmd.PersistentFlags().StringP("factory", "f", "", "Factory to list targets for")
 
 	if err := viper.BindPFlags(targetsCmd.PersistentFlags()); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.3.2
 	github.com/theupdateframework/notary v0.6.1
+	gopkg.in/yaml.v2 v2.2.2
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -52,11 +53,11 @@ func (c *Config) ReadClientCredentials() {
 
 	fmt.Print("Client ID: ")
 	scanner.Scan()
-	clientId := scanner.Text()
+	clientId := strings.Trim(scanner.Text(), " ")
 
 	fmt.Print("Client secret: ")
 	scanner.Scan()
-	clientSecret := scanner.Text()
+	clientSecret := strings.Trim(scanner.Text(), " ")
 
 	if clientId == "" || clientSecret == "" {
 		fmt.Println("Client ID and client credentials are both required.")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,7 +47,9 @@ func (c *Config) ReadClientCredentials() {
 
 	scanner := bufio.NewScanner(os.Stdin)
 
-	fmt.Printf("Please provide the client ID and client secret\n\n")
+	fmt.Println("Please provide the client ID and client secret.")
+	fmt.Printf("To obtain your client ID and client secret, please go to: https://app.foundries.io/settings/tokens/\n\n")
+
 	fmt.Print("Client ID: ")
 	scanner.Scan()
 	clientId := scanner.Text()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,7 +60,7 @@ func (c *Config) ReadClientCredentials() {
 	clientSecret := strings.Trim(scanner.Text(), " ")
 
 	if clientId == "" || clientSecret == "" {
-		fmt.Println("Client ID and client credentials are both required.")
+		fmt.Println("Client ID and client secret are both required.")
 		os.Exit(1)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+type Config struct {
+	Token string `yaml:"token,omitempty"`
+
+	ClientCredentials struct {
+		ClientId     string  `yaml:"client_id,omitempty"`
+		ClientSecret string  `yaml:"client_secret,omitempty"`
+		TokenType    string  `yaml:"token_type,omitempty"`
+		AccessToken  string  `yaml:"access_token,omitempty"`
+		RefreshToken string  `yaml:"refresh_token,omitempty"`
+		ExpiresIn    float64 `yaml:"expires_in,omitempty"`
+		Created      string  `yaml:"created,omitempty"`
+	}
+}
+
+// Save the config data to file.
+func (c *Config) Save(f string) {
+	logrus.Debug("Saving config file")
+
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	err = ioutil.WriteFile(f, data, 0600)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+// ReadClientCredentials read client id and secret from stdin.
+func (c *Config) ReadClientCredentials() {
+	logrus.Debug("Reading client ID/secret from stdin")
+
+	scanner := bufio.NewScanner(os.Stdin)
+
+	fmt.Printf("Please provide the client ID and client secret\n\n")
+	fmt.Print("Client ID: ")
+	scanner.Scan()
+	clientId := scanner.Text()
+
+	fmt.Print("Client secret: ")
+	scanner.Scan()
+	clientSecret := scanner.Text()
+
+	if clientId == "" || clientSecret == "" {
+		fmt.Println("Client ID and client credentials are both required.")
+		os.Exit(1)
+	}
+
+	c.ClientCredentials.ClientId = clientId
+	c.ClientCredentials.ClientSecret = clientSecret
+}
+
+// Load the provided YAML config file.
+func Load(f string) *Config {
+	logrus.Debug("Loading yaml config file", f)
+	var c Config
+
+	// Suppress the error: in case it doesn't exist we return an empty struct.
+	source, _ := ioutil.ReadFile(f)
+
+	err := yaml.Unmarshal(source, &c)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	return &c
+}

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -1,0 +1,190 @@
+package oauth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/foundriesio/fioctl/internal/config"
+	"github.com/sirupsen/logrus"
+)
+
+const uri string = "https://app.foundries.io/oauth"
+
+// OAuth interface.
+type OAuth interface {
+	Get() int
+	HasRefreshToken() bool
+	IsExpired() (bool, error)
+	Refresh() int
+	post(string, url.Values) (*[]byte, error)
+}
+
+// The ClientCredentials struct implements the OAuth interface for the
+// client_credentials/refresh_token OAuth grant types.
+type ClientCredentials struct {
+	Config *config.Config
+	URL    string
+}
+
+type OAuthResponse struct {
+	TokenType    string  `json:"token_type"`
+	AccessToken  string  `json:"access_token"`
+	RefreshToken string  `json:"refresh_token"`
+	ExpiresIn    float64 `json:"expires_in"`
+	Scope        string  `json:"scope"`
+}
+
+func buildUrl(uri string, p string) (string, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", err
+	}
+
+	u.Path = path.Join(u.Path, p)
+	if !strings.HasSuffix(u.Path, "/") {
+		u.Path += "/"
+	}
+
+	return u.String(), nil
+}
+
+func updateConfig(c *config.Config, r *OAuthResponse) {
+	c.ClientCredentials.AccessToken = r.AccessToken
+	c.ClientCredentials.RefreshToken = r.RefreshToken
+	c.ClientCredentials.TokenType = r.TokenType
+	c.ClientCredentials.ExpiresIn = r.ExpiresIn
+	c.ClientCredentials.Created = time.Now().UTC().Format(time.RFC3339)
+}
+
+// Perform a POST request.
+func (c *ClientCredentials) post(uri string, data url.Values) (*[]byte, error) {
+	res, err := http.PostForm(uri, data)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("Unable to retrieve credentials: HTTP_%d\n=%s", res.StatusCode, body)
+	}
+
+	return &body, nil
+}
+
+// IsExpired checks if the OAuth token is expired.
+func (c *ClientCredentials) IsExpired() (bool, error) {
+	if c.Config.ClientCredentials.ExpiresIn != 0 && c.Config.ClientCredentials.Created != "" {
+		t, err := time.Parse(time.RFC3339, c.Config.ClientCredentials.Created)
+		if err != nil {
+			return false, fmt.Errorf("Error parsing oauth token creation date")
+		}
+
+		if time.Since(t).Seconds() > c.Config.ClientCredentials.ExpiresIn {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// HasRefreshToken checks if a refresh token is available.
+func (c *ClientCredentials) HasRefreshToken() bool {
+	if c.Config.ClientCredentials.RefreshToken != "" {
+		return true
+	}
+	return false
+}
+
+// Refresh performs a refresh of the token.
+func (c *ClientCredentials) Refresh() int {
+	logrus.Debug("Refreshing client_credentials oauth token")
+
+	u, err := buildUrl(c.URL, "token")
+	if err != nil {
+		fmt.Println("ERROR: ")
+		fmt.Println(err)
+		return 1
+	}
+
+	logrus.Debug("Refreshing oauth token via URL ", u)
+
+	v := url.Values{}
+	v.Set("grant_type", "refresh_token")
+	v.Set("client_id", c.Config.ClientCredentials.ClientId)
+	v.Set("client_secret", c.Config.ClientCredentials.ClientSecret)
+	v.Set("refresh_token", c.Config.ClientCredentials.RefreshToken)
+
+	data, err := c.post(u, v)
+	if err != nil {
+		fmt.Println("ERROR: ")
+		fmt.Println(err)
+		return 1
+	}
+
+	t := OAuthResponse{}
+	err = json.Unmarshal(*data, &t)
+
+	if err != nil {
+		fmt.Println("ERROR: ")
+		fmt.Println(err)
+		return 2
+	}
+
+	updateConfig(c.Config, &t)
+
+	return 0
+}
+
+// Get a new token.
+func (c *ClientCredentials) Get() int {
+	logrus.Debug("Getting oauth token via client_credentials grant")
+
+	u, err := buildUrl(c.URL, "token")
+	if err != nil {
+		fmt.Println("ERROR: ")
+		fmt.Println(err)
+		return 1
+	}
+
+	logrus.Debug("Getting oauth token via URL ", u)
+
+	v := url.Values{}
+	v.Set("grant_type", "client_credentials")
+	v.Set("client_id", c.Config.ClientCredentials.ClientId)
+	v.Set("client_secret", c.Config.ClientCredentials.ClientSecret)
+
+	data, err := c.post(u, v)
+	if err != nil {
+		fmt.Println("ERROR: ")
+		fmt.Println(err)
+		return 1
+	}
+
+	t := OAuthResponse{}
+	err = json.Unmarshal(*data, &t)
+
+	if err != nil {
+		fmt.Println("ERROR: ")
+		fmt.Println(err)
+		return 2
+	}
+
+	updateConfig(c.Config, &t)
+
+	return 0
+}
+
+// GetClient creates and returns a new OAuth client.
+func GetClient(c *config.Config) OAuth {
+	return &ClientCredentials{c, uri}
+}


### PR DESCRIPTION
This adds the `login` command: there is no logic yet to use the OAuth token obtained after login to perform the API calls.

We need to update the `client` to use the config as loaded from file and add some logic in there as well: it needs to be able to refresh the token if it's expired before using it for any API calls.