### PR TITLE
Have targets-prune remove unused docker apps

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -113,6 +113,7 @@ type TufCustom struct {
 	TargetFormat string               `json:"targetFormat,omitempty"`
 	Version      string               `json:"version,omitempty"`
 	DockerApps   map[string]DockerApp `json:"docker_apps,omitempty"`
+	Name         string               `json:"name,omitempty"`
 }
 
 func NewApiClient(serverUrl string, config Config) *Api {

--- a/cmd/targets_prune.go
+++ b/cmd/targets_prune.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	tuf "github.com/theupdateframework/notary/tuf/data"
 )
 
 var targetsPruneCmd = &cobra.Command{
@@ -53,6 +54,40 @@ func sortedListsMatch(a, b []string) bool {
 	return true
 }
 
+func findUnusedApps(targets *tuf.SignedTargets, deleted_list []string) []string {
+	apps := make(map[string]int)
+	referenced := make([]string, 0, 100)
+	for name, target := range targets.Signed.Targets {
+		custom, err := api.TargetCustom(target)
+		if err != nil {
+			fmt.Printf("ERROR: %s\n", err)
+		} else {
+			if custom.TargetFormat == "BINARY" && strings.HasSuffix(custom.Name, ".dockerapp") {
+				apps[name] = 0
+			}
+			if !intersectionInSlices([]string{name}, deleted_list) {
+				for _, app := range custom.DockerApps {
+					if len(app.FileName) > 0 {
+						referenced = append(referenced, app.FileName)
+					}
+				}
+			}
+		}
+	}
+
+	for _, app := range referenced {
+		delete(apps, app)
+	}
+
+	unused := make([]string, len(apps))
+	i := 0
+	for app := range apps {
+		unused[i] = app
+		i++
+	}
+	return unused
+}
+
 func doTargetsPrune(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
 
@@ -87,6 +122,10 @@ func doTargetsPrune(cmd *cobra.Command, args []string) {
 		}
 		target_names = args
 	}
+
+	unused := findUnusedApps(targets, target_names)
+	target_names = append(target_names, unused...)
+
 	fmt.Printf("Deleting targets:\n %s\n", strings.Join(target_names, "\n "))
 	if pruneDryRun {
 		fmt.Println("Dry run, exiting")


### PR DESCRIPTION
This helps reduce the size of target.json by also removing .dockerapp
files in the reposerver that are no longer referenced as a result of
removing a target(s).

Signed-off-by: Andy Doan <andy@foundries.io>