### PR TITLE
login: Set default factory if there is one

### DIFF
--- a/client/oauth.go
+++ b/client/oauth.go
@@ -23,11 +23,16 @@ type OAuthConfig struct {
 	RefreshToken string  `mapstructure:"refresh_token"`
 	ExpiresIn    float64 `mapstructure:"expires_in"`
 	Created      string
+	DefaultOrg   string
 }
 
 type ClientCredentials struct {
 	Config OAuthConfig
 	URL    string
+}
+
+type Org struct {
+	Name string `json:"name"`
 }
 
 type OAuthResponse struct {
@@ -36,6 +41,7 @@ type OAuthResponse struct {
 	RefreshToken string  `json:"refresh_token"`
 	ExpiresIn    float64 `json:"expires_in"`
 	Scope        string  `json:"scope"`
+	Orgs         []Org   `json:"orgs"`
 }
 
 func buildUrl(uri string, p string) (string, error) {
@@ -58,6 +64,9 @@ func (c *ClientCredentials) updateConfig(r OAuthResponse) {
 	c.Config.TokenType = r.TokenType
 	c.Config.ExpiresIn = r.ExpiresIn
 	c.Config.Created = time.Now().UTC().Format(time.RFC3339)
+	if len(r.Orgs) == 0 {
+		c.Config.DefaultOrg = r.Orgs[0].Name
+	}
 }
 
 // Perform a POST request.

--- a/subcommands/common.go
+++ b/subcommands/common.go
@@ -109,6 +109,9 @@ func SaveOauthConfig(c client.OAuthConfig) {
 	}
 	val := viper.Get("clientcredentials")
 	cfg["clientcredentials"] = val
+	if len(c.DefaultOrg) > 0 {
+		cfg["factory"] = c.DefaultOrg
+	}
 	buf, err = yaml.Marshal(cfg)
 	if err != nil {
 		fmt.Println("Unable to marshall oauth config: ", err)


### PR DESCRIPTION
Most customers only belong to a single factory(org). This change detects
that and provides them the default they'll want in their fioctl config
so that they won't have to use the "-f" flag in commands requiring a
factory name.

Signed-off-by: Andy Doan <andy@foundries.io>