### PR TITLE
client: Use the UTC aware device listing

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -177,7 +177,7 @@ func (d Device) Online(inactiveHoursThreshold int) bool {
 	if len(d.LastSeen) == 0 {
 		return false
 	}
-	t, err := time.Parse("2006-01-02T15:04:05", d.LastSeen)
+	t, err := time.Parse("2006-01-02T15:04:05+00:00", d.LastSeen)
 	if err == nil {
 		duration := time.Since(t)
 		if duration.Hours() > float64(inactiveHoursThreshold) {
@@ -225,7 +225,7 @@ func NewApiClient(serverUrl string, config Config, caCertPath string) *Api {
 }
 
 func (a *Api) setReqHeaders(req *http.Request, jsonContent bool) {
-	req.Header.Set("User-Agent", "fioctl")
+	req.Header.Set("User-Agent", "fioctl-2")
 
 	if len(a.config.Token) > 0 {
 		logrus.Debug("Using API token for http request")


### PR DESCRIPTION
The original OTA Lite API was return UTC timestamps but did not indicate
that. In order to prevent breaking older versions of fioctl, the API
was updated to return the non tz-aware timestamps to callers with the
"fioctl" user agent. By changing this value, fioctl will get the new
TZ aware timestamp.

Signed-off-by: Andy Doan <andy@foundries.io>