### PR TITLE
Add sub-command to trigger a system image assembling

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -689,6 +689,23 @@ func (a *Api) TargetDeleteTargets(factory string, target_names []string) (string
 	return pr.JobServUrl + "runs/UpdateTargets/console.log", nil
 }
 
+func (a *Api) TargetImageCreate(factory string, targetName string) (string, error) {
+	url := a.serverUrl + "/ota/factories/" + factory + "/targets/" + targetName + "/images/"
+	resp, err := a.Post(url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	type PatchResp struct {
+		JobServUrl string `json:"jobserv-url"`
+	}
+	pr := PatchResp{}
+	if err := json.Unmarshal(*resp, &pr); err != nil {
+		return "", err
+	}
+	return pr.JobServUrl + "runs/assemble-system-image/console.log", nil
+}
+
 func (a *Api) TargetTests(factory string, target int) (*TargetTestList, error) {
 	url := a.serverUrl + "/ota/factories/" + factory + "/targets/" + strconv.Itoa(target) + "/testing/"
 	logrus.Debugf("TargetTests with url: %s", url)

--- a/subcommands/targets/image.go
+++ b/subcommands/targets/image.go
@@ -1,0 +1,32 @@
+package targets
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	cmd.AddCommand(&cobra.Command{
+		Use:   "image <target>",
+		Short: "Generate a system image with pre-loaded container images",
+		Run:   doImage,
+		Args:  cobra.ExactArgs(1),
+	})
+}
+
+func doImage(cmd *cobra.Command, args []string) {
+	factory := viper.GetString("factory")
+	inputTarget := args[0]
+	logrus.Debugf("Generating image of Target %s in Factory %s", inputTarget, factory)
+
+	url, err := api.TargetImageCreate(factory, inputTarget)
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("CI URL: %s\n", url)
+}


### PR DESCRIPTION
Add sub-command to `targets` command to invoke ota-lite API handler
that invokes a JobServe CI job for assembling of a system image of the specified Target.
Format: `fioctl targets image <Target>`

depends on https://git.foundries.io/development/cloudplatforms/infrastructure/ota-lite/merge_requests/39

Signed-off-by: Mike Sul <mike.sul@foundries.io>