### PR TITLE
Fix dockerbuild by adding g++

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,6 +3,7 @@ FROM golang:1.15-alpine
 
 RUN apk add --update --no-cache \
     git \
+    g++ \ 
     make
 
 RUN mkdir -p $HOME/fioctl


### PR DESCRIPTION
Since `g++` is not available from the container since it is not installed, attempts to follow the build instructions and run `make container-init` fail with:

`exec: "gcc": executable file not found in $PATH`

**Additionally, I have updated the container to 1.15**, the latest at this time after testing that it builds fine against it.

It should also be noted that it spits the files out in $PWD/bin with root:root ownership, I don't know what the best way to fix this is, at the moment.