### PR TITLE
client: set default org if orgs == 1, rather than == 0 - Fixes #52

### DIFF
--- a/client/oauth.go
+++ b/client/oauth.go
@@ -64,7 +64,7 @@ func (c *ClientCredentials) updateConfig(r OAuthResponse) {
 	c.Config.TokenType = r.TokenType
 	c.Config.ExpiresIn = r.ExpiresIn
 	c.Config.Created = time.Now().UTC().Format(time.RFC3339)
-	if len(r.Orgs) == 0 {
+	if len(r.Orgs) == 1 {
 		c.Config.DefaultOrg = r.Orgs[0].Name
 	}
 }


### PR DESCRIPTION
Signed-off-by: Matthew Croughan <matthew.croughan@foundries.io>

Currently we only set the default `factory:` in `~/.config/fioctl.yaml` if a member is in 0 orgs. If a member is in 0 orgs then there is no factory that they are a member of. This logic means that if a user is a member of 1 factory/org, they will not have a default set which is incorrect.
