### PR TITLE
bug #50 - don't save creds for bad login

### DIFF
--- a/subcommands/login/cmd.go
+++ b/subcommands/login/cmd.go
@@ -27,7 +27,6 @@ func doLogin(cmd *cobra.Command, args []string) {
 	creds := client.NewClientCredentials(subcommands.Config.ClientCredentials)
 	if creds.Config.ClientId == "" || creds.Config.ClientSecret == "" {
 		creds.Config.ClientId, creds.Config.ClientSecret = promptForCreds()
-		subcommands.SaveOauthConfig(creds.Config)
 	}
 
 	if creds.Config.ClientId == "" || creds.Config.ClientSecret == "" {


### PR DESCRIPTION
We already have logic to save the credentials if they are valid. There's
no point saving them initially - especially since they can be invalid
and cause the user to need to manually edit fioctl.yaml

Signed-off-by: Andy Doan <andy@foundries.io>