### PR TITLE
Add hidden command to generate RST docs

### DIFF
--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+var docsCmd = &cobra.Command{
+	Use:    "gen-rst [<directory to save files>]",
+	Short:  "Generate RST docs for this tool",
+	Hidden: true,
+	Args:   cobra.MaximumNArgs(1),
+	Run:    doGenDocs,
+}
+
+func doGenDocs(cmd *cobra.Command, args []string) {
+	outDir := "./"
+	if len(args) == 1 {
+		outDir = args[0]
+	}
+	fmt.Println("Generating docs at:", outDir)
+
+	filePrepender := func(filename string) string {
+		return ":orphan:\n\n"
+	}
+
+	linkHandler := func(name, ref string) string {
+		return fmt.Sprintf(":ref:`%s <%s>`", name, ref)
+	}
+
+	rootCmd.DisableAutoGenTag = true
+	err := doc.GenReSTTreeCustom(rootCmd, outDir, filePrepender, linkHandler)
+	if err != nil {
+		fmt.Println("ERROR:", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,8 @@ func init() {
 	rootCmd.AddCommand(status.NewCommand())
 	rootCmd.AddCommand(targets.NewCommand())
 	rootCmd.AddCommand(version.NewCommand())
+
+	rootCmd.AddCommand(docsCmd)
 }
 
 func getConfigDir() string {

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -135,6 +136,7 @@ github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubrpZHtQLnOf6EwhN2hEMusxZOhcW9H3UQ=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/subcommands/config/set.go
+++ b/subcommands/config/set.go
@@ -34,7 +34,7 @@ Basic use can be done with command line arguments. eg:
 
 The configuration format also allows specifying what command to
 run after a configuration file is updated on the device. To take
-advantage of this, the "--raw" flag must be used. eg:
+advantage of this, the "--raw" flag must be used. eg::
 
   cat >tmp.json <<EOF
   {

--- a/subcommands/devices/config_set.go
+++ b/subcommands/devices/config_set.go
@@ -41,7 +41,7 @@ Basic use can be done with command line arguments. eg:
 
 The device configuration format also allows specifying what command
 to run after a configuration file is updated on the device. To take
-advantage of this, the "--raw" flag must be used. eg:
+advantage of this, the "--raw" flag must be used. eg::
 
   cat >tmp.json <<EOF
   {


### PR DESCRIPTION
We can use this new `fioctl gen-rst` in conjunction with our docs to automagically produce CLI reference docs for this tool.