### PR TITLE
Include aktualizr config in device-show

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -108,6 +108,7 @@ type Device struct {
 	UpToDate      bool             `json:"up-to-date"`
 	PublicKey     string           `json:"public-key"`
 	ActiveConfig  *DeviceConfig    `json:"active-config,omitempty"`
+	AktualizrToml string           `json:"aktualizr-toml,omitempty"`
 }
 
 type DeviceList struct {

--- a/subcommands/devices/show.go
+++ b/subcommands/devices/show.go
@@ -75,6 +75,12 @@ func doShow(cmd *cobra.Command, args []string) {
 			}
 		}
 	}
+	if len(device.AktualizrToml) > 0 {
+		fmt.Println("Aktualizr-lite configuration:")
+		for _, line := range strings.Split(device.AktualizrToml, "\n") {
+			fmt.Printf("\t| %s\n", line)
+		}
+	}
 	if len(device.PublicKey) > 0 {
 		fmt.Println()
 		fmt.Print(device.PublicKey)


### PR DESCRIPTION
The ota-lite API now includes this optional data.

Signed-off-by: Andy Doan <andy@foundries.io>