### PR TITLE
Filter HW info with devices show parameter

### DIFF
--- a/subcommands/devices/show.go
+++ b/subcommands/devices/show.go
@@ -12,13 +12,19 @@ import (
 	"github.com/foundriesio/fioctl/subcommands"
 )
 
+var (
+	showHWInfo bool
+)
+
 func init() {
-	cmd.AddCommand(&cobra.Command{
+	showCmd := &cobra.Command{
 		Use:   "show <name>",
 		Short: "Show details of a specific device",
 		Run:   doShow,
 		Args:  cobra.ExactArgs(1),
-	})
+	}
+	cmd.AddCommand(showCmd)
+	showCmd.Flags().BoolVarP(&showHWInfo, "hwinfo", "i", false, "Show HW Information")
 }
 
 func doShow(cmd *cobra.Command, args []string) {
@@ -57,9 +63,13 @@ func doShow(cmd *cobra.Command, args []string) {
 		if err != nil {
 			fmt.Println("Unable to marshall hardware info: ", err)
 		}
-		fmt.Printf("Hardware Info:\n\t")
-		os.Stdout.Write(b)
-		fmt.Println("")
+		if showHWInfo {
+			fmt.Printf("Hardware Info:\n\t")
+			os.Stdout.Write(b)
+			fmt.Println("")
+		} else {
+			fmt.Printf("Hardware Info: (hidden, use --hwinfo)\n")
+		}
 	}
 	if device.ActiveConfig != nil {
 		fmt.Println("Active Config:")


### PR DESCRIPTION
In many cases, the information gathered by hwinfo can be quite
long.  This makes it hard to see the basic information.

Let's make the following changes to "device show":
- Hide the Hardware Information section by default with a hint
  on how to show it if needed.
- Add a --hwinfo parameter to display the Hardware Information
  section.

Signed-off-by: Michael Scott <mike@foundries.io>