### PR TITLE
Generalize factory and device config commands, add ability to manage device group config

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -667,13 +667,16 @@ func (a *Api) FactoryDeleteConfig(factory, filename string) error {
 	return err
 }
 
-func (a *Api) FactoryPatchConfig(factory string, cfg ConfigCreateRequest) error {
+func (a *Api) FactoryPatchConfig(factory string, cfg ConfigCreateRequest, force bool) error {
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		return err
 	}
 
 	url := a.serverUrl + "/ota/factories/" + factory + "/config/"
+	if force {
+		url += "?force=1"
+	}
 	logrus.Debug("Creating new factory config")
 	_, err = a.Patch(url, data)
 	return err
@@ -709,13 +712,16 @@ func (a *Api) GroupDeleteConfig(factory, group, filename string) error {
 	return err
 }
 
-func (a *Api) GroupPatchConfig(factory, group string, cfg ConfigCreateRequest) error {
+func (a *Api) GroupPatchConfig(factory, group string, cfg ConfigCreateRequest, force bool) error {
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		return err
 	}
 
 	url := a.serverUrl + "/ota/factories/" + factory + "/device-groups/" + group + "/config/"
+	if force {
+		url += "?force=1"
+	}
 	logrus.Debug("Creating new device group config")
 	_, err = a.Patch(url, data)
 	return err

--- a/client/foundries.go
+++ b/client/foundries.go
@@ -59,7 +59,7 @@ type ConfigCreateRequest struct {
 
 type DeviceConfig struct {
 	CreatedAt string       `json:"created-at"`
-	AppliedAt string       `json:"applied-at"`
+	AppliedAt string       `json:"applied-at"` // This is not present in factory config
 	Reason    string       `json:"reason"`
 	Files     []ConfigFile `json:"files"`
 }
@@ -682,10 +682,53 @@ func (a *Api) FactoryPatchConfig(factory string, cfg ConfigCreateRequest) error 
 func (a *Api) FactoryListConfig(factory string) (*DeviceConfigList, error) {
 	url := a.serverUrl + "/ota/factories/" + factory + "/config/"
 	logrus.Debugf("FactoryListConfig with url: %s", url)
-	return a.DeviceListConfigCont(url)
+	return a.FactoryListConfigCont(url)
 }
 
 func (a *Api) FactoryListConfigCont(url string) (*DeviceConfigList, error) {
+	// A short cut as it behaves just the same
+	return a.DeviceListConfigCont(url)
+}
+
+func (a *Api) GroupCreateConfig(factory, group string, cfg ConfigCreateRequest) error {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+
+	url := a.serverUrl + "/ota/factories/" + factory + "/device-groups/" + group + "/config/"
+	logrus.Debug("Creating new device group config")
+	_, err = a.Post(url, data)
+	return err
+}
+
+func (a *Api) GroupDeleteConfig(factory, group, filename string) error {
+	url := a.serverUrl + "/ota/factories/" + factory + "/device-groups/" + group + "/config/" + filename + "/"
+	logrus.Debugf("Deleting config file: %s", url)
+	_, err := a.Delete(url, nil)
+	return err
+}
+
+func (a *Api) GroupPatchConfig(factory, group string, cfg ConfigCreateRequest) error {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+
+	url := a.serverUrl + "/ota/factories/" + factory + "/device-groups/" + group + "/config/"
+	logrus.Debug("Creating new device group config")
+	_, err = a.Patch(url, data)
+	return err
+}
+
+func (a *Api) GroupListConfig(factory, group string) (*DeviceConfigList, error) {
+	url := a.serverUrl + "/ota/factories/" + factory + "/device-groups/" + group + "/config/"
+	logrus.Debugf("GroupListConfig with url: %s", url)
+	return a.GroupListConfigCont(url)
+}
+
+func (a *Api) GroupListConfigCont(url string) (*DeviceConfigList, error) {
+	// A short cut as it behaves just the same
 	return a.DeviceListConfigCont(url)
 }
 

--- a/subcommands/common.go
+++ b/subcommands/common.go
@@ -5,12 +5,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
@@ -124,36 +122,6 @@ func initViper(cmd *cobra.Command) {
 		os.Exit(1)
 	}
 	Config.Token = viper.GetString("token")
-}
-
-func PrintConfigs(deviceConfigs []client.DeviceConfig, listLimit int) int {
-	firstRow := color.New(color.FgYellow)
-	for idx, cfg := range deviceConfigs {
-		if idx != 0 {
-			fmt.Println("")
-		}
-		firstRow.Printf("Created At:    %s\n", cfg.CreatedAt)
-		fmt.Printf("Applied At:    %s\n", cfg.AppliedAt)
-		fmt.Printf("Change Reason: %s\n", cfg.Reason)
-		fmt.Println("Files:")
-		for _, f := range cfg.Files {
-			if len(f.OnChanged) == 0 {
-				fmt.Printf("\t%s\n", f.Name)
-			} else {
-				fmt.Printf("\t%s - %v\n", f.Name, f.OnChanged)
-			}
-			if f.Unencrypted {
-				for _, line := range strings.Split(f.Value, "\n") {
-					fmt.Printf("\t | %s\n", line)
-				}
-			}
-		}
-		listLimit -= 1
-		if listLimit == 0 {
-			return 0
-		}
-	}
-	return listLimit
 }
 
 func DieNotNil(err error) {

--- a/subcommands/common_config.go
+++ b/subcommands/common_config.go
@@ -24,6 +24,9 @@ type SetConfigOptions struct {
 func SetConfig(opts *SetConfigOptions) {
 	cfg := client.ConfigCreateRequest{Reason: opts.Reason}
 	if opts.IsRawFile {
+		if len(opts.FileArgs) != 1 {
+			DieNotNil(fmt.Errorf("Raw file only accepts one file argument"))
+		}
 		ReadConfig(opts.FileArgs[0], &cfg)
 	} else {
 		for _, keyval := range opts.FileArgs {

--- a/subcommands/common_config.go
+++ b/subcommands/common_config.go
@@ -155,7 +155,7 @@ func SetUpdatesConfig(opts *SetUpdatesConfigOptions) {
 
 	dcl, err := opts.ListFunc()
 	if !opts.IsForced {
-		DieNotNil(err, "Failed to fetch existing config change log (override with --force):")
+		DieNotNil(err, "Failed to fetch existing config changelog (override with --force):")
 	}
 	sota, err := loadSotaConfig(dcl)
 	if !opts.IsForced {

--- a/subcommands/common_config.go
+++ b/subcommands/common_config.go
@@ -1,0 +1,72 @@
+package subcommands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+
+	"github.com/foundriesio/fioctl/client"
+)
+
+type LogConfigsOptions struct {
+	Limit         int
+	ShowAppliedAt bool
+	ListFunc      func() (*client.DeviceConfigList, error)
+	ListContFunc  func(string) (*client.DeviceConfigList, error)
+}
+
+func LogConfigs(opts *LogConfigsOptions) {
+	var dcl *client.DeviceConfigList
+	listLimit := opts.Limit
+	for {
+		var err error
+		if dcl == nil {
+			dcl, err = opts.ListFunc()
+		} else {
+			if dcl.Next != nil {
+				dcl, err = opts.ListContFunc(*dcl.Next)
+			} else {
+				return
+			}
+		}
+		DieNotNil(err)
+		for _, cfg := range dcl.Configs {
+			PrintConfig(&cfg, opts.ShowAppliedAt, true, "")
+			if listLimit -= 1; listLimit == 0 {
+				return
+			} else {
+				fmt.Println("")
+			}
+		}
+	}
+}
+
+func PrintConfig(cfg *client.DeviceConfig, showAppliedAt, highlightFirstLine bool, indent string) {
+	firstLine := fmt.Printf
+	if highlightFirstLine {
+		firstLine = color.New(color.FgYellow).Printf
+	}
+	printf := func(format string, a ...interface{}) {
+		fmt.Printf(indent+format, a...)
+	}
+
+	firstLine(indent+"Created At:    %s\n", cfg.CreatedAt)
+	if showAppliedAt {
+		printf("Applied At:    %s\n", cfg.AppliedAt)
+	}
+	printf("Change Reason: %s\n", cfg.Reason)
+	printf("Files:\n")
+	for _, f := range cfg.Files {
+		if len(f.OnChanged) == 0 {
+			printf("\t%s\n", f.Name)
+		} else {
+			printf("\t%s - %v\n", f.Name, f.OnChanged)
+		}
+		if f.Unencrypted {
+			for _, line := range strings.Split(f.Value, "\n") {
+				printf("\t | %s\n", line)
+			}
+		}
+	}
+}

--- a/subcommands/common_config.go
+++ b/subcommands/common_config.go
@@ -99,15 +99,16 @@ func ReadConfig(configFile string, cfg *client.ConfigCreateRequest) {
 }
 
 func PrintConfig(cfg *client.DeviceConfig, showAppliedAt, highlightFirstLine bool, indent string) {
-	firstLine := fmt.Printf
-	if highlightFirstLine {
-		firstLine = color.New(color.FgYellow).Printf
-	}
 	printf := func(format string, a ...interface{}) {
 		fmt.Printf(indent+format, a...)
 	}
 
-	firstLine(indent+"Created At:    %s\n", cfg.CreatedAt)
+	if highlightFirstLine {
+		firstLine := color.New(color.FgYellow)
+		firstLine.Printf(indent+"Created At:    %s\n", cfg.CreatedAt)
+	} else {
+		printf("Created At:    %s\n", cfg.CreatedAt)
+	}
 	if showAppliedAt {
 		printf("Applied At:    %s\n", cfg.AppliedAt)
 	}

--- a/subcommands/common_config.go
+++ b/subcommands/common_config.go
@@ -5,12 +5,22 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/fatih/color"
+	toml "github.com/pelletier/go-toml"
 	"github.com/sirupsen/logrus"
 
 	"github.com/foundriesio/fioctl/client"
+)
+
+// Aktualizr puts all config files into a single lexographically sorted map.
+// We have to make sure this file is parsed *after* sota.toml.
+const (
+	FIO_TOML_NAME        = "z-50-fioctl.toml"
+	FIO_COMPOSE_APPS_DIR = "/var/sota/compose-apps"
+	FIO_TOML_ONCHANGED   = "/usr/share/fioconfig/handlers/aktualizr-toml-update"
 )
 
 type SetConfigOptions struct {
@@ -126,4 +136,147 @@ func PrintConfig(cfg *client.DeviceConfig, showAppliedAt, highlightFirstLine boo
 			}
 		}
 	}
+}
+
+type SetUpdatesConfigOptions struct {
+	UpdateTags     string
+	UpdateApps     string
+	SetComposeApps bool
+	ComposeAppsDir string
+	IsDryRun       bool
+	IsForced       bool
+	Device         *client.Device
+	ListFunc       func() (*client.DeviceConfigList, error)
+	SetFunc        func(client.ConfigCreateRequest, bool) error
+}
+
+func SetUpdatesConfig(opts *SetUpdatesConfigOptions) {
+	DieNotNil(validateUpdateArgs(opts))
+
+	dcl, err := opts.ListFunc()
+	if !opts.IsForced {
+		DieNotNil(err, "Failed to fetch existing config change log (override with --force):")
+	}
+	sota, err := loadSotaConfig(dcl)
+	if !opts.IsForced {
+		DieNotNil(err, "Invalid FIO toml file (override with --force):")
+	}
+
+	if opts.UpdateApps == "" && opts.UpdateTags == "" && !opts.SetComposeApps {
+		if opts.Device != nil {
+			fmt.Println("= Reporting to server with")
+			fmt.Println(" Tags: ", strings.Join(opts.Device.Tags, ","))
+			fmt.Println(" Apps: ", strings.Join(opts.Device.DockerApps, ","))
+			fmt.Println("")
+		}
+		fmt.Println("= Configured overrides")
+		fmt.Println(sota)
+		return
+	}
+
+	configuredApps := sota.GetDefault("pacman.docker_apps", "").(string)
+	configuredTags := sota.GetDefault("pacman.tags", "").(string)
+	configuredMgr := sota.GetDefault("pacman.packagemanager", "").(string)
+
+	changed := false
+	if opts.UpdateApps != "" && configuredApps != opts.UpdateApps {
+		if strings.TrimSpace(opts.UpdateApps) == "," {
+			opts.UpdateApps = ""
+		}
+		fmt.Printf("Changing apps from: [%s] -> [%s]\n", configuredApps, opts.UpdateApps)
+		sota.Set("pacman.docker_apps", opts.UpdateApps)
+		sota.Set("pacman.compose_apps", opts.UpdateApps)
+		changed = true
+	}
+	if opts.UpdateTags != "" && configuredTags != opts.UpdateTags {
+		if strings.TrimSpace(opts.UpdateTags) == "," {
+			opts.UpdateTags = ""
+		}
+		fmt.Printf("Changing tags from: [%s] -> [%s]\n", configuredTags, opts.UpdateTags)
+		sota.Set("pacman.tags", opts.UpdateTags)
+		changed = true
+	}
+	if opts.SetComposeApps && configuredMgr != "ostree+compose_apps" {
+		fmt.Printf("Changing packagemanager to %s\n", "ostree+compose_apps")
+		sota.Set("pacman.type", "ostree+compose_apps")
+		if opts.ComposeAppsDir == "" {
+			opts.ComposeAppsDir = FIO_COMPOSE_APPS_DIR
+		}
+		sota.Set("pacman.compose_apps_root", opts.ComposeAppsDir)
+		// the device might be running DockerApps that were set in /var/sota/sota.toml
+		// by lmp-device-register, so fallback to what its reporting if we don't find
+		// override values set:
+		defaultApps := ""
+		if opts.Device != nil {
+			defaultApps = strings.Join(opts.Device.DockerApps, ",")
+		}
+		sota.Set("pacman.compose_apps", sota.GetDefault("pacman.docker_apps", defaultApps))
+		changed = true
+	} else if opts.ComposeAppsDir != "" {
+		fmt.Println("Can only change compose apps dir when migrating to compose apps.")
+	}
+
+	if !changed {
+		DieNotNil(fmt.Errorf(
+			"No changes found. Device is already configured with the specified options."))
+	}
+
+	newToml, err := sota.ToTomlString()
+	DieNotNil(err, "Unable to encode toml:")
+
+	cfg := client.ConfigCreateRequest{
+		Reason: "Override aktualizr-lite update configuration ",
+		Files: []client.ConfigFile{
+			{
+				Name:        FIO_TOML_NAME,
+				Unencrypted: true,
+				OnChanged:   []string{"/usr/share/fioconfig/handlers/aktualizr-toml-update"},
+				Value:       newToml,
+			},
+		},
+	}
+	if opts.IsDryRun {
+		fmt.Println(newToml)
+	} else {
+		DieNotNil(opts.SetFunc(cfg, opts.IsForced))
+	}
+}
+
+func loadSotaConfig(dcl *client.DeviceConfigList) (sota *toml.Tree, err error) {
+	found := false
+	if dcl != nil && len(dcl.Configs) > 0 {
+		for _, cfgFile := range dcl.Configs[0].Files {
+			if cfgFile.Name == FIO_TOML_NAME {
+				sota, err = toml.Load(cfgFile.Value)
+				if err != nil {
+					err = fmt.Errorf("Unable to decode toml: %w\n- TOML is: %s", err, cfgFile.Value)
+				}
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		logrus.Debugf("Not found a FIO toml in the latest config")
+	}
+	// In case if FIO TOML file is missing or an error - return an empty one.
+	// Let a caller decide what to do in case of an error.
+	if !found || err != nil {
+		sota, _ = toml.Load("[pacman]")
+	}
+	return
+}
+
+func validateUpdateArgs(opts *SetUpdatesConfigOptions) error {
+	// Validate the inputs: Must be alphanumeric, a dash, underscore, or comma
+	pattern := `^[a-zA-Z0-9-_,]+$`
+	re := regexp.MustCompile(pattern)
+	if len(opts.UpdateApps) > 0 && !re.MatchString(opts.UpdateApps) {
+		return fmt.Errorf("Invalid value for apps: %s\nMust be %s", opts.UpdateApps, pattern)
+	}
+	if len(opts.UpdateTags) > 0 && !re.MatchString(opts.UpdateTags) {
+		return fmt.Errorf("Invalid value for tags: %s\nMust be %s", opts.UpdateTags, pattern)
+	}
+	return nil
 }

--- a/subcommands/config/cmd.go
+++ b/subcommands/config/cmd.go
@@ -8,8 +8,7 @@ import (
 )
 
 var (
-	api       *client.Api
-	listLimit int
+	api *client.Api
 )
 
 var cmd = &cobra.Command{

--- a/subcommands/config/delete.go
+++ b/subcommands/config/delete.go
@@ -9,17 +9,26 @@ import (
 )
 
 func init() {
-	cmd.AddCommand(&cobra.Command{
+	deleteCmd := &cobra.Command{
 		Use:   "delete <file>",
 		Short: "Delete file from the current configuration",
 		Run:   doConfigDelete,
 		Args:  cobra.ExactArgs(1),
-	})
+	}
+	cmd.AddCommand(deleteCmd)
+	deleteCmd.Flags().StringP("group", "g", "", "Device group to use")
 }
 
 func doConfigDelete(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
-	logrus.Debugf("Deleting file from config for %s", factory)
+	group, _ := cmd.Flags().GetString("group")
+	filename := args[0]
 
-	subcommands.DieNotNil(api.FactoryDeleteConfig(factory, args[0]))
+	if group == "" {
+		logrus.Debugf("Deleting file %s from config for %s", filename, factory)
+		subcommands.DieNotNil(api.FactoryDeleteConfig(factory, filename))
+	} else {
+		logrus.Debugf("Deleting file %s from config for %s group %s", filename, factory, group)
+		subcommands.DieNotNil(api.GroupDeleteConfig(factory, group, filename))
+	}
 }

--- a/subcommands/config/log.go
+++ b/subcommands/config/log.go
@@ -12,32 +12,36 @@ import (
 func init() {
 	logCmd := &cobra.Command{
 		Use:   "log",
-		Short: "Changelog of configuration",
+		Short: "Show a change log of configuration",
 		Run:   doConfigLog,
 	}
 	cmd.AddCommand(logCmd)
-	logCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Limit the number of results displayed.")
+	logCmd.Flags().StringP("group", "g", "", "Device group to use")
+	logCmd.Flags().IntP("limit", "n", 0, "Limit the number of results displayed")
 }
 
 func doConfigLog(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
-	logrus.Debugf("Showing config history for %s", factory)
-	var dcl *client.DeviceConfigList
-	for {
-		var err error
-		if dcl == nil {
-			dcl, err = api.FactoryListConfig(factory)
-		} else {
-			if dcl.Next != nil {
-				dcl, err = api.FactoryListConfigCont(*dcl.Next)
-			} else {
-				break
-			}
-		}
-		subcommands.DieNotNil(err)
-		listLimit = subcommands.PrintConfigs(dcl.Configs, listLimit)
-		if listLimit == 0 {
-			break
-		}
+	listLimit, _ := cmd.Flags().GetInt("limit")
+	group, _ := cmd.Flags().GetString("group")
+
+	if group == "" {
+		logrus.Debugf("Showing config history for %s", factory)
+		subcommands.LogConfigs(&subcommands.LogConfigsOptions{
+			Limit: listLimit,
+			ListFunc: func() (*client.DeviceConfigList, error) {
+				return api.FactoryListConfig(factory)
+			},
+			ListContFunc: api.FactoryListConfigCont,
+		})
+	} else {
+		logrus.Debugf("Showing config history for %s group %s", factory, group)
+		subcommands.LogConfigs(&subcommands.LogConfigsOptions{
+			Limit: listLimit,
+			ListFunc: func() (*client.DeviceConfigList, error) {
+				return api.GroupListConfig(factory, group)
+			},
+			ListContFunc: api.GroupListConfigCont,
+		})
 	}
 }

--- a/subcommands/config/log.go
+++ b/subcommands/config/log.go
@@ -12,7 +12,7 @@ import (
 func init() {
 	logCmd := &cobra.Command{
 		Use:   "log",
-		Short: "Show a change log of configuration",
+		Short: "Show a changelog of configuration",
 		Run:   doConfigLog,
 	}
 	cmd.AddCommand(logCmd)

--- a/subcommands/config/set.go
+++ b/subcommands/config/set.go
@@ -51,6 +51,8 @@ advantage of this, the "--raw" flag must be used. eg::
 fioctl will read in tmp.json and upload it to the OTA server.
 Instead of using ./tmp.json, the command can take a "-" and will read the
 content from STDIN instead of a file.
+
+Use a -g or --group parameter to create a device group wide configuration instead.
 `,
 		Run:  doConfigSet,
 		Args: cobra.MinimumNArgs(1),
@@ -76,19 +78,18 @@ func doConfigSet(cmd *cobra.Command, args []string) {
 			if shouldCreate {
 				return api.FactoryCreateConfig(factory, cfg)
 			} else {
-				return api.FactoryPatchConfig(factory, cfg)
+				return api.FactoryPatchConfig(factory, cfg, false)
 			}
 		}
-		subcommands.SetConfig(&opts)
 	} else {
 		logrus.Debugf("Creating new config for %s group %s", factory, group)
 		opts.SetFunc = func(cfg client.ConfigCreateRequest) error {
 			if shouldCreate {
 				return api.GroupCreateConfig(factory, group, cfg)
 			} else {
-				return api.GroupPatchConfig(factory, group, cfg)
+				return api.GroupPatchConfig(factory, group, cfg, false)
 			}
 		}
-		subcommands.SetConfig(&opts)
 	}
+	subcommands.SetConfig(&opts)
 }

--- a/subcommands/config/set.go
+++ b/subcommands/config/set.go
@@ -1,24 +1,12 @@
 package config
 
 import (
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"strings"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/foundriesio/fioctl/client"
 	"github.com/foundriesio/fioctl/subcommands"
-)
-
-var (
-	configReason string
-	configRaw    bool
-	configCreate bool
 )
 
 func init() {
@@ -68,52 +56,39 @@ content from STDIN instead of a file.
 		Args: cobra.MinimumNArgs(1),
 	}
 	cmd.AddCommand(setCmd)
-	setCmd.Flags().StringVarP(&configReason, "reason", "m", "", "Add a message to store as the \"reason\" for this change")
-	setCmd.Flags().BoolVarP(&configRaw, "raw", "", false, "Use raw configuration file")
-	setCmd.Flags().BoolVarP(&configCreate, "create", "", false, "Replace the whole config with these values. Default is to merge these values in with the existing config values")
-}
-
-func loadConfig(configFile string, cfg *client.ConfigCreateRequest) {
-	var content []byte
-	var err error
-
-	if configFile == "-" {
-		logrus.Debug("Reading config from STDIN")
-		content, err = ioutil.ReadAll(os.Stdin)
-	} else {
-		content, err = ioutil.ReadFile(configFile)
-	}
-	if err != nil {
-		fmt.Printf("ERROR: Unable to read config file: %v\n", err)
-		os.Exit(1)
-	}
-	if err := json.Unmarshal(content, cfg); err != nil {
-		fmt.Printf("ERROR: Unable to parse config file: %v\n", err)
-		os.Exit(1)
-	}
+	setCmd.Flags().StringP("group", "g", "", "Device group to use")
+	setCmd.Flags().StringP("reason", "m", "", "Add a message to store as the \"reason\" for this change")
+	setCmd.Flags().BoolP("raw", "", false, "Use raw configuration file")
+	setCmd.Flags().BoolP("create", "", false, "Replace the whole config with these values. Default is to merge these values in with the existing config values")
 }
 
 func doConfigSet(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
-	logrus.Debugf("Creating new config for %s", factory)
+	group, _ := cmd.Flags().GetString("group")
+	reason, _ := cmd.Flags().GetString("reason")
+	isRaw, _ := cmd.Flags().GetBool("raw")
+	shouldCreate, _ := cmd.Flags().GetBool("create")
+	opts := subcommands.SetConfigOptions{FileArgs: args, Reason: reason, IsRawFile: isRaw}
 
-	cfg := client.ConfigCreateRequest{Reason: configReason}
-	if configRaw {
-		loadConfig(args[0], &cfg)
-	} else {
-		for _, keyval := range args {
-			parts := strings.SplitN(keyval, "=", 2)
-			if len(parts) != 2 {
-				fmt.Println("ERROR: Invalid file=content argument: ", keyval)
-				os.Exit(1)
+	if group == "" {
+		logrus.Debugf("Creating new config for %s", factory)
+		opts.SetFunc = func(cfg client.ConfigCreateRequest) error {
+			if shouldCreate {
+				return api.FactoryCreateConfig(factory, cfg)
+			} else {
+				return api.FactoryPatchConfig(factory, cfg)
 			}
-			cfg.Files = append(cfg.Files, client.ConfigFile{Name: parts[0], Value: parts[1]})
 		}
-	}
-
-	if configCreate {
-		subcommands.DieNotNil(api.FactoryCreateConfig(factory, cfg))
+		subcommands.SetConfig(&opts)
 	} else {
-		subcommands.DieNotNil(api.FactoryPatchConfig(factory, cfg))
+		logrus.Debugf("Creating new config for %s group %s", factory, group)
+		opts.SetFunc = func(cfg client.ConfigCreateRequest) error {
+			if shouldCreate {
+				return api.GroupCreateConfig(factory, group, cfg)
+			} else {
+				return api.GroupPatchConfig(factory, group, cfg)
+			}
+		}
+		subcommands.SetConfig(&opts)
 	}
 }

--- a/subcommands/config/updates.go
+++ b/subcommands/config/updates.go
@@ -1,8 +1,9 @@
-package devices
+package config
 
 import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/foundriesio/fioctl/client"
 	"github.com/foundriesio/fioctl/subcommands"
@@ -13,29 +14,31 @@ func init() {
 		Use:   "updates <device>",
 		Short: "Configure aktualizr-lite settings for how updates are applied to a device",
 		Run:   doConfigUpdates,
-		Args:  cobra.ExactArgs(1),
-		Long: `View or change configuration parameters used by aktualizr-lite for updating a device.
-When run with no options, this command will print out how the device is
-currently configured and reporting. Configuration can be updated with commands
+		Long: `View or change factory wide configuration parameters used by aktualizr-lite for updating a device.
+When run with no options, this command will print out how the factory is
+currently configured. Configuration can be updated with commands
 like:
 
   # Make a device start taking updates from Targets tagged with "devel"
-  fioctl devices config updates <device> --tags devel
+  fioctl config updates <device> --tags devel
 
   # Make a device start taking updates from 2 different tags:
-  fioctl devices config updates <device> --tags devel,devel-foo
+  fioctl config updates <device> --tags devel,devel-foo
 
   # Set the docker apps a device will run:
-  fioctl devices config updates <device> --apps shellhttpd
+  fioctl config updates <device> --apps shellhttpd
 
   # Set the docker apps and the tag:
-  fioctl devices config updates <device> --apps shellhttpd --tags master
+  fioctl config updates <device> --apps shellhttpd --tags master
 
   # Move device from old docker-apps to compose-apps:
-  fioctl devices config updates <device> --compose-apps
+  fioctl config updates <device> --compose-apps
+
+Use a -g or --group parameter to view or change a device group wide configuration instead.
 `,
 	}
-	configCmd.AddCommand(configUpdatesCmd)
+	cmd.AddCommand(configUpdatesCmd)
+	configUpdatesCmd.Flags().StringP("group", "g", "", "Device group to use")
 	configUpdatesCmd.Flags().StringP("tags", "", "", "comma,separate,list")
 	configUpdatesCmd.Flags().StringP("apps", "", "", "comma,separate,list")
 	configUpdatesCmd.Flags().BoolP("compose-apps", "", false, "Migrate device from docker-apps to compose-apps")
@@ -47,7 +50,8 @@ like:
 }
 
 func doConfigUpdates(cmd *cobra.Command, args []string) {
-	name := args[0]
+	factory := viper.GetString("factory")
+	group, _ := cmd.Flags().GetString("group")
 	updateApps, _ := cmd.Flags().GetString("apps")
 	updateTags, _ := cmd.Flags().GetString("tags")
 	setComposeApps, _ := cmd.Flags().GetBool("compose-apps")
@@ -55,24 +59,31 @@ func doConfigUpdates(cmd *cobra.Command, args []string) {
 	isDryRun, _ := cmd.Flags().GetBool("dryrun")
 	isForced, _ := cmd.Flags().GetBool("force")
 
-	logrus.Debugf("Configuring device updates for %s", name)
-
-	device, err := api.DeviceGet(name)
-	subcommands.DieNotNil(err, "Failed to fetch a device:")
-
-	subcommands.SetUpdatesConfig(&subcommands.SetUpdatesConfigOptions{
+	opts := subcommands.SetUpdatesConfigOptions{
 		UpdateApps:     updateApps,
 		UpdateTags:     updateTags,
 		SetComposeApps: setComposeApps,
 		ComposeAppsDir: composeAppsDir,
 		IsDryRun:       isDryRun,
 		IsForced:       isForced,
-		Device:         device,
-		ListFunc: func() (*client.DeviceConfigList, error) {
-			return api.DeviceListConfig(name)
-		},
-		SetFunc: func(cfg client.ConfigCreateRequest, force bool) error {
-			return api.DevicePatchConfig(name, cfg, force)
-		},
-	})
+	}
+
+	if group == "" {
+		logrus.Debugf("Configuring device updates for %s", factory)
+		opts.ListFunc = func() (*client.DeviceConfigList, error) {
+			return api.FactoryListConfig(factory)
+		}
+		opts.SetFunc = func(cfg client.ConfigCreateRequest, force bool) error {
+			return api.FactoryPatchConfig(factory, cfg, force)
+		}
+	} else {
+		logrus.Debugf("Configuring device updates for %s group %s", factory, group)
+		opts.ListFunc = func() (*client.DeviceConfigList, error) {
+			return api.GroupListConfig(factory, group)
+		}
+		opts.SetFunc = func(cfg client.ConfigCreateRequest, force bool) error {
+			return api.GroupPatchConfig(factory, group, cfg, force)
+		}
+	}
+	subcommands.SetUpdatesConfig(&opts)
 }

--- a/subcommands/config/wireguard.go
+++ b/subcommands/config/wireguard.go
@@ -102,7 +102,7 @@ func doWireguard(cmd *cobra.Command, args []string) {
 		}
 		cfg.Files[0].Value = wsc.Marshall()
 
-		subcommands.DieNotNil(api.FactoryPatchConfig(factory, cfg))
+		subcommands.DieNotNil(api.FactoryPatchConfig(factory, cfg, false))
 	} else {
 		fmt.Println("Enabled:", wsc.Enabled)
 		if len(wsc.Endpoint) > 0 {

--- a/subcommands/devices/config_log.go
+++ b/subcommands/devices/config_log.go
@@ -11,7 +11,7 @@ import (
 func init() {
 	logConfigCmd := &cobra.Command{
 		Use:   "log <device>",
-		Short: "Show a change log of device's configuration",
+		Short: "Show a changelog of device's configuration",
 		Run:   doConfigLog,
 		Args:  cobra.ExactArgs(1),
 	}

--- a/subcommands/devices/config_log.go
+++ b/subcommands/devices/config_log.go
@@ -11,32 +11,25 @@ import (
 func init() {
 	logConfigCmd := &cobra.Command{
 		Use:   "log <device>",
-		Short: "Changelog of device's configuration",
+		Short: "Show a change log of device's configuration",
 		Run:   doConfigLog,
 		Args:  cobra.ExactArgs(1),
 	}
 	configCmd.AddCommand(logConfigCmd)
-	logConfigCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Limit the number of results displayed.")
+	logConfigCmd.Flags().IntP("limit", "n", 0, "Limit the number of results displayed.")
 }
 
 func doConfigLog(cmd *cobra.Command, args []string) {
-	logrus.Debug("Showing device config log")
-	var dcl *client.DeviceConfigList
-	for {
-		var err error
-		if dcl == nil {
-			dcl, err = api.DeviceListConfig(args[0])
-		} else {
-			if dcl.Next != nil {
-				dcl, err = api.DeviceListConfigCont(*dcl.Next)
-			} else {
-				break
-			}
-		}
-		subcommands.DieNotNil(err)
-		listLimit = subcommands.PrintConfigs(dcl.Configs, listLimit)
-		if listLimit == 0 {
-			break
-		}
-	}
+	device := args[0]
+	listLimit, _ := cmd.Flags().GetInt("limit")
+	logrus.Debug("Showing device config log for %s", device)
+
+	subcommands.LogConfigs(&subcommands.LogConfigsOptions{
+		Limit:         listLimit,
+		ShowAppliedAt: true,
+		ListFunc: func() (*client.DeviceConfigList, error) {
+			return api.DeviceListConfig(device)
+		},
+		ListContFunc: api.DeviceListConfigCont,
+	})
 }

--- a/subcommands/devices/config_log.go
+++ b/subcommands/devices/config_log.go
@@ -22,7 +22,7 @@ func init() {
 func doConfigLog(cmd *cobra.Command, args []string) {
 	device := args[0]
 	listLimit, _ := cmd.Flags().GetInt("limit")
-	logrus.Debug("Showing device config log for %s", device)
+	logrus.Debugf("Showing device config log for %s", device)
 
 	subcommands.LogConfigs(&subcommands.LogConfigsOptions{
 		Limit:         listLimit,

--- a/subcommands/devices/config_set.go
+++ b/subcommands/devices/config_set.go
@@ -6,9 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
-
 	"fmt"
-	"os"
 
 	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/sirupsen/logrus"
@@ -74,14 +72,11 @@ a "-" and will read the content from STDIN instead of a file.
 func loadEciesPub(pubkey string) *ecies.PublicKey {
 	block, _ := pem.Decode([]byte(pubkey))
 	if block == nil {
-		fmt.Println("ERROR: Failed to parse certificate PEM")
-		os.Exit(1)
+		subcommands.DieNotNil(fmt.Errorf("Failed to parse certificate PEM"))
 	}
 
 	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		fmt.Printf("ERROR: Failed to parse DER encoded public key: %v\n", err)
-	}
+	subcommands.DieNotNil(err, "Failed to parse DER encoded public key:")
 
 	ecpub := pub.(*ecdsa.PublicKey)
 	return ecies.ImportECDSAPublic(ecpub)
@@ -90,9 +85,7 @@ func loadEciesPub(pubkey string) *ecies.PublicKey {
 func eciesEncrypt(content string, pubkey *ecies.PublicKey) string {
 	message := []byte(content)
 	enc, err := ecies.Encrypt(rand.Reader, pubkey, message, nil, nil)
-	if err != nil {
-		fmt.Printf("ERROR: Cant encrypt: %v\n", err)
-	}
+	subcommands.DieNotNil(err, "Failed to encrypt:")
 	return base64.StdEncoding.EncodeToString(enc)
 }
 

--- a/subcommands/devices/config_set.go
+++ b/subcommands/devices/config_set.go
@@ -73,6 +73,7 @@ func loadEciesPub(pubkey string) *ecies.PublicKey {
 	block, _ := pem.Decode([]byte(pubkey))
 	if block == nil {
 		subcommands.DieNotNil(fmt.Errorf("Failed to parse certificate PEM"))
+		return nil // prevent go-lint error at next line
 	}
 
 	pub, err := x509.ParsePKIXPublicKey(block.Bytes)

--- a/subcommands/devices/config_set.go
+++ b/subcommands/devices/config_set.go
@@ -73,7 +73,7 @@ func loadEciesPub(pubkey string) *ecies.PublicKey {
 	block, _ := pem.Decode([]byte(pubkey))
 	if block == nil {
 		subcommands.DieNotNil(fmt.Errorf("Failed to parse certificate PEM"))
-		return nil // prevent go-lint error at next line
+		return nil // return for go linter
 	}
 
 	pub, err := x509.ParsePKIXPublicKey(block.Bytes)

--- a/subcommands/devices/show.go
+++ b/subcommands/devices/show.go
@@ -88,22 +88,7 @@ func doShow(cmd *cobra.Command, args []string) {
 	}
 	if device.ActiveConfig != nil {
 		fmt.Println("Active Config:")
-		fmt.Println("\tCreated At: ", device.ActiveConfig.CreatedAt)
-		fmt.Println("\tApplied At: ", device.ActiveConfig.AppliedAt)
-		fmt.Println("\tReason:     ", device.ActiveConfig.Reason)
-		fmt.Println("\tFiles:")
-		for _, f := range device.ActiveConfig.Files {
-			if len(f.OnChanged) == 0 {
-				fmt.Printf("\t\t%s\n", f.Name)
-			} else {
-				fmt.Printf("\t\t%s - %v\n", f.Name, f.OnChanged)
-			}
-			if f.Unencrypted {
-				for _, line := range strings.Split(f.Value, "\n") {
-					fmt.Printf("\t\t | %s\n", line)
-				}
-			}
-		}
+		subcommands.PrintConfig(device.ActiveConfig, true, false, "\t")
 	}
 	if len(device.PublicKey) > 0 {
 		fmt.Println()


### PR DESCRIPTION
There is still work to do with a non-trivial updates subcommand, but it's already possible to review config log/set/delete subcommands, all of which now behave consistently for factory/group/device config.