### PR TITLE
Add column customization to device listing

### DIFF
--- a/subcommands/devices/list.go
+++ b/subcommands/devices/list.go
@@ -2,6 +2,8 @@ package devices
 
 import (
 	"fmt"
+	"os"
+	"sort"
 	"strings"
 
 	"github.com/cheynewallace/tabby"
@@ -14,29 +16,101 @@ import (
 
 var (
 	deviceNoShared      bool
-	deviceNoOwner       bool
 	deviceByTag         string
 	deviceByFactory     string
 	deviceByGroup       string
 	deviceInactiveHours int
 	deviceUuid          string
+	showColumns         []string
 )
 
+type column struct {
+	Formatter func(d *client.Device) string
+}
+
+func statusFormatter(d *client.Device) string {
+	status := "OK"
+	if len(d.Status) > 0 {
+		status = d.Status
+	}
+	if len(d.LastSeen) > 0 && !d.Online(deviceInactiveHours) {
+		status = "OFFLINE"
+	}
+	return status
+}
+
+var ownerCache = make(map[string]string)
+
+func ownerFormatter(d *client.Device) string {
+	name, ok := ownerCache[d.Owner]
+	if ok {
+		return name
+	}
+	logrus.Debugf("Looking up user %s in factory %s", d.Owner, d.Factory)
+	users, err := api.UsersList(d.Factory)
+	if err != nil {
+		logrus.Errorf("Unable to look up users: %s", err)
+		return "???"
+	}
+	id := "<not in factory: " + d.Factory + ">"
+	for _, user := range users {
+		ownerCache[user.PolisId] = user.Name
+		if user.PolisId == d.Owner {
+			id = user.Name
+		}
+	}
+	return id
+}
+
+func groupFormatter(d *client.Device) string {
+	if d.Group != nil {
+		return d.Group.Name
+	}
+	return ""
+}
+
+var Columns = map[string]column{
+	"name":          {func(d *client.Device) string { return d.Name }},
+	"uuid":          {func(d *client.Device) string { return d.Uuid }},
+	"factory":       {func(d *client.Device) string { return d.Factory }},
+	"owner":         {ownerFormatter},
+	"device-group":  {groupFormatter},
+	"target":        {func(d *client.Device) string { return d.TargetName }},
+	"status":        {statusFormatter},
+	"apps":          {func(d *client.Device) string { return strings.Join(d.DockerApps, ",") }},
+	"up-to-date":    {func(d *client.Device) string { return fmt.Sprintf("%v", d.UpToDate) }},
+	"tags":          {func(d *client.Device) string { return strings.Join(d.Tags, ",") }},
+	"created-at":    {func(d *client.Device) string { return d.CreatedAt }},
+	"last-seen":     {func(d *client.Device) string { return d.LastSeen }},
+	"ostree-hash":   {func(d *client.Device) string { return d.OstreeHash }},
+	"curent-update": {func(d *client.Device) string { return d.CurrentUpdate }},
+}
+
 func init() {
+	var defCols = []string{
+		"name", "factory", "target", "status", "apps", "up-to-date",
+	}
+
+	allCols := make([]string, 0, len(Columns))
+	for k := range Columns {
+		allCols = append(allCols, k)
+	}
+	sort.Strings(allCols)
 	listCmd := &cobra.Command{
 		Use:   "list [pattern]",
 		Short: "List devices registered to factories. Optionally include filepath style patterns to limit to device names. eg device-*",
 		Run:   doList,
 		Args:  cobra.MaximumNArgs(1),
+		Long:  "Available columns for display:\n  * " + strings.Join(allCols, "\n  * "),
 	}
 	cmd.AddCommand(listCmd)
 	listCmd.Flags().BoolVarP(&deviceNoShared, "just-mine", "", false, "Only include devices owned by you")
-	listCmd.Flags().BoolVarP(&deviceNoOwner, "skip-owner", "", false, "Do not include owner name when lising. (command will run faster)")
 	listCmd.Flags().StringVarP(&deviceByTag, "by-tag", "", "", "Only list devices configured with the given tag")
 	listCmd.Flags().StringVarP(&deviceByFactory, "by-factory", "f", "", "Only list devices belonging to this factory")
 	listCmd.Flags().StringVarP(&deviceByGroup, "by-group", "g", "", "Only list devices belonging to this group (factory is mandatory)")
 	listCmd.Flags().IntVarP(&deviceInactiveHours, "offline-threshold", "", 4, "List the device as 'OFFLINE' if not seen in the last X hours")
 	listCmd.Flags().StringVarP(&deviceUuid, "uuid", "", "", "Find device with the given UUID")
+	listCmd.Flags().StringSliceVarP(&showColumns, "columns", "", defCols, "Specify which columns to display")
 }
 
 // We allow pattern matching using filepath.Match type * and ?
@@ -55,38 +129,19 @@ func sqlLikeIfy(filePathLike string) string {
 	return sql
 }
 
-func userName(factory, polisId string, cache map[string]string) string {
-	name, ok := cache[polisId]
-	if ok {
-		return name
-	}
-	logrus.Debugf("Looking up user %s in factory %s", polisId, factory)
-	users, err := api.UsersList(factory)
-	if err != nil {
-		logrus.Errorf("Unable to look up users: %s", err)
-		return "???"
-	}
-	id := "<not in factory: " + polisId + ">"
-	for _, user := range users {
-		cache[user.PolisId] = user.Name
-		if user.PolisId == polisId {
-			id = user.Name
-		}
-	}
-	return id
-}
-
 func doList(cmd *cobra.Command, args []string) {
 	logrus.Debug("Listing registered devices")
 
 	t := tabby.New()
-	if deviceNoOwner {
-		t.AddHeader("NAME", "FACTORY", "TARGET", "STATUS", "APPS", "UP TO DATE")
-	} else {
-		t.AddHeader("NAME", "FACTORY", "OWNER", "TARGET", "STATUS", "APPS", "UP TO DATE")
+	var cols = make([]interface{}, len(showColumns))
+	for idx, c := range showColumns {
+		if _, ok := Columns[c]; !ok {
+			fmt.Println("ERROR: Invalid column name:", c)
+			os.Exit(1)
+		}
+		cols[idx] = strings.ToUpper(c)
 	}
-
-	cache := make(map[string]string)
+	t.AddHeader(cols...)
 
 	var dl *client.DeviceList
 	for {
@@ -111,23 +166,16 @@ func doList(cmd *cobra.Command, args []string) {
 			}
 		}
 		subcommands.DieNotNil(err)
+		row := make([]interface{}, len(showColumns))
 		for _, device := range dl.Devices {
 			if len(device.TargetName) == 0 {
 				device.TargetName = "???"
 			}
-			status := "OK"
-			if len(device.Status) > 0 {
-				status = device.Status
+			for idx, col := range showColumns {
+				col := Columns[col]
+				row[idx] = col.Formatter(&device)
 			}
-			if len(device.LastSeen) > 0 && !device.Online(deviceInactiveHours) {
-				status = "OFFLINE"
-			}
-			if deviceNoOwner {
-				t.AddLine(device.Name, device.Factory, device.TargetName, status, strings.Join(device.DockerApps, ","), device.UpToDate)
-			} else {
-				owner := userName(device.Factory, device.Owner, cache)
-				t.AddLine(device.Name, device.Factory, owner, device.TargetName, status, strings.Join(device.DockerApps, ","), device.UpToDate)
-			}
+			t.AddLine(row...)
 		}
 	}
 	t.Print()


### PR DESCRIPTION
A common feature request: More/different columns to be shown in device
listing. This keeps the default the same, but allows a user to show
any columns they'd like including Tags and DeviceGroup.

Signed-off-by: Andy Doan <andy@foundries.io>