### PR TITLE
fix a device-group help message referring to device instead of device group

### DIFF
--- a/subcommands/config/device_group.go
+++ b/subcommands/config/device_group.go
@@ -43,8 +43,8 @@ func init() {
 		Args:  cobra.ExactArgs(1),
 	}
 	groupCmd.AddCommand(updateCmd)
-	updateCmd.Flags().StringP("name", "n", "", "Change a device name")
-	updateCmd.Flags().StringP("description", "d", "", "Change a device description")
+	updateCmd.Flags().StringP("name", "n", "", "Change a device group name")
+	updateCmd.Flags().StringP("description", "d", "", "Change a device group description")
 }
 
 func doListDeviceGroup(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
This fixed issue #77 