### PR TITLE
keys: Add logic for syncing production root

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -884,8 +884,16 @@ func (a *Api) GetFoundriesTargetsKey(factory string) (*AtsKey, error) {
 	return &key, err
 }
 
-func (a *Api) TufRootGet(factory string) (*AtsTufRoot, error) {
-	url := a.serverUrl + "/ota/repo/" + factory + "/api/v1/user_repo/root.json"
+func (a *Api) tufRootGet(factory string, prod bool, version int) (*AtsTufRoot, error) {
+	url := a.serverUrl + "/ota/repo/" + factory + "/api/v1/user_repo/"
+	if version > 0 {
+		url += fmt.Sprintf("%d.", version)
+	}
+	url += "root.json"
+	if prod {
+		url += "?production=1"
+	}
+	logrus.Debugf("Fetch root %s", url)
 	body, err := a.Get(url)
 	if err != nil {
 		return nil, err
@@ -894,13 +902,31 @@ func (a *Api) TufRootGet(factory string) (*AtsTufRoot, error) {
 	err = json.Unmarshal(*body, &root)
 	return &root, err
 }
-func (a *Api) TufRootPost(factory string, root []byte) (string, error) {
+func (a *Api) TufRootGet(factory string) (*AtsTufRoot, error) {
+	return a.tufRootGet(factory, false, -1)
+}
+func (a *Api) TufRootGetVer(factory string, version int) (*AtsTufRoot, error) {
+	return a.tufRootGet(factory, false, version)
+}
+func (a *Api) TufProdRootGet(factory string) (*AtsTufRoot, error) {
+	return a.tufRootGet(factory, true, -1)
+}
+func (a *Api) tufRootPost(factory string, prod bool, root []byte) (string, error) {
 	url := a.serverUrl + "/ota/repo/" + factory + "/api/v1/user_repo/root"
+	if prod {
+		url += "?production=1"
+	}
 	body, err := a.Post(url, root)
 	if body != nil {
 		return string(*body), err
 	}
 	return "", err
+}
+func (a *Api) TufRootPost(factory string, root []byte) (string, error) {
+	return a.tufRootPost(factory, false, root)
+}
+func (a *Api) TufProdRootPost(factory string, root []byte) (string, error) {
+	return a.tufRootPost(factory, true, root)
 }
 
 func (a *Api) TargetsListRaw(factory string) (*[]byte, error) {

--- a/subcommands/keys/rotate_root.go
+++ b/subcommands/keys/rotate_root.go
@@ -70,11 +70,15 @@ func doRotateRoot(cmd *cobra.Command, args []string) {
 	}
 	subcommands.DieNotNil(signRoot(root, signers...))
 
+	tufRootPost(factory, credsFile, root, newCreds)
+}
+
+func tufRootPost(factory, credsFile string, root *client.AtsTufRoot, creds OfflineCreds) {
 	bytes, err := json.Marshal(root)
 	subcommands.DieNotNil(err)
 
 	// Create a backup before we try and commit this:
-	tmpCreds := saveTempCreds(credsFile, newCreds)
+	tmpCreds := saveTempCreds(credsFile, creds)
 
 	fmt.Println("= Uploading rotated root")
 	body, err := api.TufRootPost(factory, bytes)

--- a/subcommands/keys/rotate_root.go
+++ b/subcommands/keys/rotate_root.go
@@ -91,8 +91,11 @@ func tufRootPost(factory, credsFile string, root *client.AtsTufRoot, creds Offli
 
 	fmt.Println("= Uploading rotated root")
 	body, err := api.TufRootPost(factory, bytes)
-	if err != nil {
-		fmt.Println("\nERROR:", err)
+	if herr := client.AsHttpError(err); herr != nil && herr.Response.StatusCode == 409 {
+		fmt.Println("ERROR: Your production root role is out of sync. Please run `fioctl rotate root --sync-prod` to fix this.")
+		os.Exit(1)
+	} else if err != nil {
+		fmt.Println("\nERROR: ", err)
 		fmt.Println(body)
 		fmt.Println("A temporary copy of the new root was saved:", tmpCreds)
 		fmt.Println("Before deleting this please ensure your factory isn't configured with this new key")

--- a/subcommands/keys/rotate_targets.go
+++ b/subcommands/keys/rotate_targets.go
@@ -1,10 +1,8 @@
 package keys
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -52,21 +50,7 @@ func doRotateTargets(cmd *cobra.Command, args []string) {
 	fmt.Println("= New target:", targetid)
 	subcommands.DieNotNil(signRoot(root, TufSigner{rootid, rootPk}))
 
-	tmpCreds := saveTempCreds(credsFile, newCreds)
-
-	bytes, err := json.MarshalIndent(root, "", "  ")
-	subcommands.DieNotNil(err)
-	fmt.Println("= Uploading new root")
-	body, err := api.TufRootPost(factory, bytes)
-	if err != nil {
-		fmt.Println("\nERROR:", err)
-		fmt.Println(body)
-		os.Exit(1)
-	}
-	if err := os.Rename(tmpCreds, credsFile); err != nil {
-		fmt.Println("\nERROR: Unable to update offline creds file.", err)
-		fmt.Println("Temp copy still available at:", tmpCreds)
-	}
+	tufRootPost(factory, credsFile, root, newCreds)
 }
 
 func findOnlineTargetId(factory string, root client.AtsTufRoot, creds OfflineCreds) (string, error) {

--- a/subcommands/keys/rotate_targets.go
+++ b/subcommands/keys/rotate_targets.go
@@ -48,6 +48,7 @@ func doRotateTargets(cmd *cobra.Command, args []string) {
 	subcommands.DieNotNil(err)
 	targetid, newCreds := replaceOfflineTargetKey(root, onlineTargetId, creds)
 	fmt.Println("= New target:", targetid)
+	removeUnusedKeys(root)
 	subcommands.DieNotNil(signRoot(root, TufSigner{rootid, rootPk}))
 
 	tufRootPost(factory, credsFile, root, newCreds)


### PR DESCRIPTION
A production root is the *exact* same as the root.json used in CI except
is has a targets signing threshold of 2.

Signed-off-by: Andy Doan <andy@foundries.io>