### PR TITLE
Change pagination logic of device-list

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -611,15 +611,15 @@ func (a *Api) DeviceGet(device string) (*Device, error) {
 	return &d, nil
 }
 
-func (a *Api) DeviceList(shared bool, matchTag, byFactory, byGroup, nameIlike, uuid string) (*DeviceList, error) {
+func (a *Api) DeviceList(shared bool, matchTag, byFactory, byGroup, nameIlike, uuid string, page, limit int) (*DeviceList, error) {
 	sharedInt := 0
 	if shared {
 		sharedInt = 1
 	}
 	url := a.serverUrl + "/ota/devices/?"
 	url += fmt.Sprintf(
-		"shared=%d&match_tag=%s&name_ilike=%s&factory=%s&uuid=%s&group=%s",
-		sharedInt, matchTag, nameIlike, byFactory, uuid, byGroup)
+		"shared=%d&match_tag=%s&name_ilike=%s&factory=%s&uuid=%s&group=%s&page=%d&limit=%d",
+		sharedInt, matchTag, nameIlike, byFactory, uuid, byGroup, page, limit)
 	logrus.Debugf("DeviceList with url: %s", url)
 	return a.DeviceListCont(url)
 }

--- a/subcommands/devices/config_wireguard.go
+++ b/subcommands/devices/config_wireguard.go
@@ -93,7 +93,7 @@ func factoryIps(factory string) map[uint32]bool {
 	for {
 		var err error
 		if dl == nil {
-			dl, err = api.DeviceList(true, "", factory, "", "", "")
+			dl, err = api.DeviceList(true, "", factory, "", "", "", 1, 1000)
 		} else {
 			if dl.Next != nil {
 				dl, err = api.DeviceListCont(*dl.Next)

--- a/subcommands/devices/list.go
+++ b/subcommands/devices/list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/cheynewallace/tabby"
@@ -22,6 +23,9 @@ var (
 	deviceInactiveHours int
 	deviceUuid          string
 	showColumns         []string
+	showPage            int
+	paginationLimit     int
+	paginationLimits    []int
 )
 
 type column struct {
@@ -84,6 +88,14 @@ func init() {
 	var defCols = []string{
 		"name", "factory", "target", "status", "apps", "up-to-date", "is-prod",
 	}
+	paginationLimits = []int{10, 20, 30, 40, 50, 100, 200, 500, 1000}
+	limitsStr := ""
+	for i, limit := range paginationLimits {
+		if i > 0 {
+			limitsStr += ","
+		}
+		limitsStr += strconv.Itoa(limit)
+	}
 
 	allCols := make([]string, 0, len(Columns))
 	for k := range Columns {
@@ -105,6 +117,8 @@ func init() {
 	listCmd.Flags().IntVarP(&deviceInactiveHours, "offline-threshold", "", 4, "List the device as 'OFFLINE' if not seen in the last X hours")
 	listCmd.Flags().StringVarP(&deviceUuid, "uuid", "", "", "Find device with the given UUID")
 	listCmd.Flags().StringSliceVarP(&showColumns, "columns", "", defCols, "Specify which columns to display")
+	listCmd.Flags().IntVarP(&showPage, "page", "p", 1, "Page of devices to display when pagination is needed")
+	listCmd.Flags().IntVarP(&paginationLimit, "limit", "n", 500, "Number of devices to paginate by. Allowed values: "+limitsStr)
 }
 
 // We allow pattern matching using filepath.Match type * and ?
@@ -123,8 +137,19 @@ func sqlLikeIfy(filePathLike string) string {
 	return sql
 }
 
+func assertPagination() {
+	// hack until: https://github.com/spf13/pflag/issues/236
+	for _, x := range paginationLimits {
+		if x == paginationLimit {
+			return
+		}
+	}
+	subcommands.DieNotNil(fmt.Errorf("Invalid limit: %d", paginationLimit))
+}
+
 func doList(cmd *cobra.Command, args []string) {
 	logrus.Debug("Listing registered devices")
+	assertPagination()
 
 	t := tabby.New()
 	var cols = make([]interface{}, len(showColumns))
@@ -137,40 +162,48 @@ func doList(cmd *cobra.Command, args []string) {
 	}
 	t.AddHeader(cols...)
 
-	var dl *client.DeviceList
-	for {
-		var err error
-		if dl == nil {
-			name_ilike := ""
-			if len(args) == 1 {
-				name_ilike = sqlLikeIfy(args[0])
-			}
-			if len(deviceByFactory) > 0 {
-				deviceNoShared = true
-			} else if len(deviceByGroup) > 0 {
-				subcommands.DieNotNil(fmt.Errorf("A factory is mandatory to filter by group"))
-			}
-			dl, err = api.DeviceList(
-				!deviceNoShared, deviceByTag, deviceByFactory, deviceByGroup, name_ilike, deviceUuid)
-		} else {
-			if dl.Next != nil {
-				dl, err = api.DeviceListCont(*dl.Next)
-			} else {
-				break
-			}
+	name_ilike := ""
+	if len(args) == 1 {
+		name_ilike = sqlLikeIfy(args[0])
+	}
+	if len(deviceByFactory) > 0 {
+		deviceNoShared = true
+	} else if len(deviceByGroup) > 0 {
+		subcommands.DieNotNil(fmt.Errorf("A factory is mandatory to filter by group"))
+	}
+	dl, err := api.DeviceList(!deviceNoShared, deviceByTag, deviceByFactory, deviceByGroup, name_ilike, deviceUuid, showPage, paginationLimit)
+	subcommands.DieNotNil(err)
+	row := make([]interface{}, len(showColumns))
+	for _, device := range dl.Devices {
+		if len(device.TargetName) == 0 {
+			device.TargetName = "???"
 		}
-		subcommands.DieNotNil(err)
-		row := make([]interface{}, len(showColumns))
-		for _, device := range dl.Devices {
-			if len(device.TargetName) == 0 {
-				device.TargetName = "???"
-			}
-			for idx, col := range showColumns {
-				col := Columns[col]
-				row[idx] = col.Formatter(&device)
-			}
-			t.AddLine(row...)
+		for idx, col := range showColumns {
+			col := Columns[col]
+			row[idx] = col.Formatter(&device)
 		}
+		t.AddLine(row...)
 	}
 	t.Print()
+	if dl.Next != nil {
+		fmt.Print("\nNext page of devices can be viewed with: ")
+		found := false
+		for i := 0; i < len(os.Args); i++ {
+			arg := os.Args[i]
+			if len(arg) > 2 && arg[:2] == "-p" {
+				fmt.Printf("-p%d ", showPage+1)
+				found = true
+			} else if len(arg) == 6 && arg[:6] == "--page" {
+				fmt.Printf("-p%d ", showPage+1)
+				found = true
+				i++
+			} else {
+				fmt.Print(os.Args[i], " ")
+			}
+		}
+		if !found {
+			fmt.Print("-p", showPage+1)
+		}
+		fmt.Println()
+	}
 }


### PR DESCRIPTION
As we grow in the number of devices inside factories, our logic to
show everything in one pass breaks down. The backend now gives us 200
devices at a time. In the case there are more, the "-p <page>" argument
can be added to work through the device. Or, better yet, use filtering
logic.

Signed-off-by: Andy Doan <andy@foundries.io>