### PR TITLE
status: Include device-group information

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -173,14 +173,20 @@ type TargetStatus struct {
 	IsOrphan     bool `json:"is-orphan"`
 }
 
+type DeviceGroupStatus struct {
+	GroupId    int `json:"group-id"`
+	NumDevices int `json:"devices"`
+}
+
 type TagStatus struct {
-	Name            string         `json:"name"`
-	DevicesTotal    int            `json:"devices-total"`
-	DevicesOnline   int            `json:"devices-online"`
-	DevicesOnLatest int            `json:"devices-on-latest"`
-	DevicesOnOrphan int            `json:"devices-on-orphan"`
-	LatestTarget    int            `json:"latest-target"`
-	Targets         []TargetStatus `json:"targets"`
+	Name            string              `json:"name"`
+	DevicesTotal    int                 `json:"devices-total"`
+	DevicesOnline   int                 `json:"devices-online"`
+	DevicesOnLatest int                 `json:"devices-on-latest"`
+	DevicesOnOrphan int                 `json:"devices-on-orphan"`
+	LatestTarget    int                 `json:"latest-target"`
+	Targets         []TargetStatus      `json:"targets"`
+	DeviceGroups    []DeviceGroupStatus `json:"device-groups"`
 }
 
 type FactoryStatus struct {


### PR DESCRIPTION
The status API now includes important information about device groups
that helps operators understand/plan OTAs

Signed-off-by: Andy Doan <andy@foundries.io>