### PR TITLE
Require factory for list devices

### DIFF
--- a/subcommands/devices/cmd.go
+++ b/subcommands/devices/cmd.go
@@ -53,8 +53,7 @@ fioctl devices updates <device> $(fioctl devices updates <device> -n1 | tail -n1
 }
 
 func NewCommand() *cobra.Command {
-	cmd.PersistentFlags().StringP("token", "t", "", "API token from https://app.foundries.io/settings/tokens/")
-
+	subcommands.RequireFactory(cmd)
 	updatesCmd.Flags().IntVarP(&listLimit, "limit", "n", 0, "Limit the number of updates displayed.")
 
 	cmd.AddCommand(configCmd)


### PR DESCRIPTION
Most users only belong to a single factory in the first place. Listing
across all factories introduces pain points in the backend. Its just a
relic of "pre factory foundries" stuff we did.

Signed-off-by: Andy Doan <andy@foundries.io>