### PR TITLE
Include device-group information into a factory status

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -173,14 +173,24 @@ type TargetStatus struct {
 	IsOrphan     bool `json:"is-orphan"`
 }
 
+type DeviceGroupStatus struct {
+	Name            string `json:"name"`
+	DevicesTotal    int    `json:"devices-total"`
+	DevicesOnline   int    `json:"devices-online"`
+	DevicesOnLatest int    `json:"devices-on-latest"`
+	DevicesOnOrphan int    `json:"devices-on-orphan"`
+	Reinstalling    int    `json:"(re-)installing"`
+}
+
 type TagStatus struct {
-	Name            string         `json:"name"`
-	DevicesTotal    int            `json:"devices-total"`
-	DevicesOnline   int            `json:"devices-online"`
-	DevicesOnLatest int            `json:"devices-on-latest"`
-	DevicesOnOrphan int            `json:"devices-on-orphan"`
-	LatestTarget    int            `json:"latest-target"`
-	Targets         []TargetStatus `json:"targets"`
+	Name            string              `json:"name"`
+	DevicesTotal    int                 `json:"devices-total"`
+	DevicesOnline   int                 `json:"devices-online"`
+	DevicesOnLatest int                 `json:"devices-on-latest"`
+	DevicesOnOrphan int                 `json:"devices-on-orphan"`
+	LatestTarget    int                 `json:"latest-target"`
+	Targets         []TargetStatus      `json:"targets"`
+	DeviceGroups    []DeviceGroupStatus `json:"device-groups"`
 }
 
 type FactoryStatus struct {

--- a/subcommands/status/cmd.go
+++ b/subcommands/status/cmd.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cheynewallace/tabby"
 	"github.com/sirupsen/logrus"
@@ -99,6 +100,35 @@ func printTargetStatus(tagPrefix string, tagStatus []client.TagStatus) {
 			}
 			fmt.Printf("\t%-6d%-1s  %-7d  %-10d  %s\n",
 				tgt.Version, orphan, tgt.Devices, tgt.Reinstalling, details)
+		}
+
+		if len(tag.DeviceGroups) > 0 {
+			// Tabby doesn't indent (or at least easily) so calculate name column width here
+			longestNameLen := 0
+			for _, g := range tag.DeviceGroups {
+				if len(g.Name) > longestNameLen {
+					longestNameLen = len(g.Name)
+				}
+			}
+			dgHeader := "DEVICE GROUP"
+			if longestNameLen > len(dgHeader) {
+				dgHeader += strings.Repeat(" ", longestNameLen-len(dgHeader))
+			} else {
+				longestNameLen = len(dgHeader)
+			}
+
+			fmt.Println()
+			fmt.Printf("\t%s  DEVICES  ON LATEST  ONLINE  INSTALLING\n", dgHeader)
+			fmt.Printf("\t%s  -------  ---------  ------  ----------\n",
+				strings.Repeat("-", len(dgHeader)))
+			for _, g := range tag.DeviceGroups {
+				name := g.Name
+				if len(name) < longestNameLen {
+					name += strings.Repeat(" ", longestNameLen-len(name))
+				}
+				fmt.Printf("\t%s  %-7d  %-9d  %-6d  %d\n",
+					name, g.DevicesTotal, g.DevicesOnLatest, g.DevicesOnline, g.Reinstalling)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This adds a device group details info a factory status, similar to how we do this for wave status.

Example output (for one tag):
```
## Production Tag: beta
	TARGET   DEVICES  INSTALLING  DETAILS
	-------  -------  ----------  -------
	683      1        0           `fioctl targets show 683`
	617      1        0           `fioctl targets show 617`
	0     *  2        1           

	DEVICE GROUP  DEVICES  ON LATEST  ONLINE  INSTALLING
	------------  -------  ---------  ------  ----------
	new           1        1          0       0
	test          2        0          0       1
```