### PR TITLE
keys: Use 4096bit RSA keys

### DIFF
--- a/subcommands/keys/rotate_root.go
+++ b/subcommands/keys/rotate_root.go
@@ -152,7 +152,7 @@ type keypair struct {
 }
 
 func genKeyPair() keypair {
-	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	pk, err := rsa.GenerateKey(rand.Reader, 4096)
 	subcommands.DieNotNil(err)
 
 	var privBytes []byte = x509.MarshalPKCS1PrivateKey(pk)


### PR DESCRIPTION
2048 bit keys are not recommended

Signed-off-by: Andy Doan <andy@foundries.io>