### PR TITLE
Fix some issues when displaying target information

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -216,7 +216,6 @@ type TufCustom struct {
 	Tags           []string              `json:"tags,omitempty"`
 	TargetFormat   string                `json:"targetFormat,omitempty"`
 	Version        string                `json:"version,omitempty"`
-	DockerApps     map[string]DockerApp  `json:"docker_apps,omitempty"`
 	ComposeApps    map[string]ComposeApp `json:"docker_compose_apps,omitempty"`
 	Name           string                `json:"name,omitempty"`
 	ContainersSha  string                `json:"containers-sha,omitempty"`

--- a/client/foundries.go
+++ b/client/foundries.go
@@ -154,6 +154,11 @@ type ComposeApp struct {
 	Uri string `json:"uri"`
 }
 
+func (a ComposeApp) Hash() string {
+	parts := strings.SplitN(a.Uri, "@sha256:", 2)
+	return parts[len(parts)-1]
+}
+
 type FactoryUser struct {
 	PolisId string `json:"polis-id"`
 	Name    string `json:"name"`

--- a/client/foundries.go
+++ b/client/foundries.go
@@ -1047,6 +1047,21 @@ func (a *Api) TargetsListRaw(factory string) (*[]byte, error) {
 	return a.Get(url)
 }
 
+func (a *Api) TargetGet(factory string, targetName string) (*tuf.FileMeta, error) {
+	url := a.serverUrl + "/ota/factories/" + factory + "/targets/" + targetName
+	body, err := a.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	var target tuf.FileMeta
+	err = json.Unmarshal(*body, &target)
+	if err != nil {
+		return nil, err
+	}
+
+	return &target, nil
+}
+
 func (a *Api) TargetsList(factory string, version ...string) (tuf.Files, error) {
 	url := a.serverUrl + "/ota/factories/" + factory + "/targets/"
 	if len(version) == 1 {

--- a/subcommands/targets/list.go
+++ b/subcommands/targets/list.go
@@ -108,10 +108,6 @@ func doList(cmd *cobra.Command, args []string) {
 		} else {
 			set := make(map[string]bool)
 			var apps []string
-			for app := range custom.DockerApps {
-				apps = append(apps, app)
-				set[app] = true
-			}
 			for app := range custom.ComposeApps {
 				if _, ok := set[app]; !ok {
 					apps = append(apps, app)

--- a/subcommands/targets/list.go
+++ b/subcommands/targets/list.go
@@ -113,6 +113,7 @@ func doList(cmd *cobra.Command, args []string) {
 					apps = append(apps, app)
 				}
 			}
+			sort.Strings(apps)
 			keys = append(keys, key)
 			listing[key] = &targetListing{
 				version:     ver,
@@ -129,6 +130,9 @@ func doList(cmd *cobra.Command, args []string) {
 	sort.Sort(byTargetKey(keys))
 	for _, key := range keys {
 		l := listing[key]
+		sort.Strings(l.tags)
+		sort.Strings(l.apps)
+		sort.Strings(l.hardwareIds)
 		tags := strings.Join(l.tags, ",")
 		apps := strings.Join(l.apps, ",")
 		hwids := strings.Join(l.hardwareIds, ",")

--- a/subcommands/targets/show.go
+++ b/subcommands/targets/show.go
@@ -41,7 +41,6 @@ func doShow(cmd *cobra.Command, args []string) {
 	logrus.Debugf("Showing targets for %s %s", factory, version)
 
 	var tags []string
-	var apps map[string]client.DockerApp
 	var composeApps map[string]client.ComposeApp
 	containersSha := ""
 	manifestSha := ""
@@ -69,7 +68,6 @@ func doShow(cmd *cobra.Command, args []string) {
 			}
 			overridesSha = custom.OverridesSha
 		}
-		apps = custom.DockerApps
 		composeApps = custom.ComposeApps
 		tags = custom.Tags
 	}
@@ -99,23 +97,7 @@ func doShow(cmd *cobra.Command, args []string) {
 
 	fmt.Println()
 
-	if len(apps) > 0 {
-		t = tabby.New()
-		t.AddHeader("DOCKER APP", "VERSION")
-		for name, app := range apps {
-			if len(app.FileName) > 0 {
-				t.AddLine(name, app.FileName)
-			}
-			if len(app.Uri) > 0 {
-				t.AddLine(name, app.Uri)
-			}
-		}
-		t.Print()
-	}
 	if len(composeApps) > 0 {
-		if len(apps) > 0 {
-			fmt.Println()
-		}
 		t = tabby.New()
 		t.AddHeader("COMPOSE APP", "VERSION")
 		for name, app := range composeApps {


### PR DESCRIPTION
We used to produce "homogeneous targets" where each target-version would run the same containers and be based on the same source code. However, we now allow LMP builds to produce multiple targets that are based on different container branches and vice-versa. This means we need to be more verbose when displaying a target.

The change does 2 things:
1. you can show by target-version *and* target-name now. So `fioctl targets show raspberrypi4-64-lmp-38-production` is now valid and helpful for showing *exactly* what you need with these heterogeneous targets.
2. target-show shows each target. For example:
~~~
$ fioctl targets show 38                               
CI:	https://app.foundries.io/factories/andy-corp/targets/38/

## Target: intel-corei7-64-lmp-38-production
	Tags:        production
	OSTree Hash: f90c313df9db8afee5dcbf6eeca58223e7258f164c6a7b631ba024ad9da12631

	Source:
		https://source.foundries.io/factories/andy-corp/lmp-manifest.git/commit/?id=bc835b4a3582b8a83bc9842f6b359ebbaf6f344c
		https://source.foundries.io/factories/andy-corp/meta-subscriber-overrides.git/commit/?id=46d479f43ff1c0f6a75c1d1d9ef94156c1cc5377
		https://source.foundries.io/factories/andy-corp/containers.git/commit/?id=cb7544bb3c9b2b9e5e1b16a217b5c3a756fbbe4b

	App            HASH
	-------------  ----
	homeassistant  bafdec9c3be57056429fa1af4b3c45737bfce67fcd35c95b9b4ed421ac78d8cf
	fiotest        035fccbb398ef23f6e6a16fa2325b0439fec67868b741767e10dc9fb18f8c4ac
	ssh-container  fe68bbab22b64eaa66070dcc039f6943e1a8583fd66c4942605887b7324165cd
	shellhttpd     4a3f0b4ee0bdbded9632f97f171d90c46a77ee2bc497ccfb1670a869e3e6833e
	code-server    ba46608bcb82bf7489b4b4786298f88930cfed1d6ddbc65b39efc005a3b4b73f
	homelab        a485df077640f8c39425f63ad0d3986593f849dc3c1942f0f1037a336a12aee7

## Target: raspberrypi4-64-lmp-38-production
	Tags:        production
	OSTree Hash: c99788113a7b05aceffd4a4bdafc2039ab9af16100282b67bf3bb74705468d9a

	Source:
		https://source.foundries.io/factories/andy-corp/lmp-manifest.git/commit/?id=bc835b4a3582b8a83bc9842f6b359ebbaf6f344c
		https://source.foundries.io/factories/andy-corp/meta-subscriber-overrides.git/commit/?id=46d479f43ff1c0f6a75c1d1d9ef94156c1cc5377
		https://source.foundries.io/factories/andy-corp/containers.git/commit/?id=cb7544bb3c9b2b9e5e1b16a217b5c3a756fbbe4b

	App            HASH
	-------------  ----
	shellhttpd     4a3f0b4ee0bdbded9632f97f171d90c46a77ee2bc497ccfb1670a869e3e6833e
	code-server    ba46608bcb82bf7489b4b4786298f88930cfed1d6ddbc65b39efc005a3b4b73f
	homelab        a485df077640f8c39425f63ad0d3986593f849dc3c1942f0f1037a336a12aee7
	homeassistant  bafdec9c3be57056429fa1af4b3c45737bfce67fcd35c95b9b4ed421ac78d8cf
	fiotest        035fccbb398ef23f6e6a16fa2325b0439fec67868b741767e10dc9fb18f8c4ac
	ssh-container  fe68bbab22b64eaa66070dcc039f6943e1a8583fd66c4942605887b7324165cd

## Target: intel-corei7-64-lmp-38-master
	Tags:        master
	OSTree Hash: fd255123ae0598aa0cc734781a89236cfedd4a3e519afb07ee3880823e2e645b

	Source:
		https://source.foundries.io/factories/andy-corp/lmp-manifest.git/commit/?id=8aa6164a4b27e9c0dcbe3e263a1a40f8a4ad1cd5
		https://source.foundries.io/factories/andy-corp/meta-subscriber-overrides.git/commit/?id=46d479f43ff1c0f6a75c1d1d9ef94156c1cc5377
		https://source.foundries.io/factories/andy-corp/containers.git/commit/?id=cb7544bb3c9b2b9e5e1b16a217b5c3a756fbbe4b

	App            HASH
	-------------  ----
	ssh-container  fe68bbab22b64eaa66070dcc039f6943e1a8583fd66c4942605887b7324165cd
	shellhttpd     4a3f0b4ee0bdbded9632f97f171d90c46a77ee2bc497ccfb1670a869e3e6833e
	code-server    ba46608bcb82bf7489b4b4786298f88930cfed1d6ddbc65b39efc005a3b4b73f
	homelab        a485df077640f8c39425f63ad0d3986593f849dc3c1942f0f1037a336a12aee7
	homeassistant  bafdec9c3be57056429fa1af4b3c45737bfce67fcd35c95b9b4ed421ac78d8cf
	fiotest        035fccbb398ef23f6e6a16fa2325b0439fec67868b741767e10dc9fb18f8c4ac

## Target: raspberrypi4-64-lmp-38-master
	Tags:        master
	OSTree Hash: a338772ac6507d9aa48ddd3b796293f27ae4f1471fa239670920e5d9d8acfb64

	Source:
		https://source.foundries.io/factories/andy-corp/lmp-manifest.git/commit/?id=8aa6164a4b27e9c0dcbe3e263a1a40f8a4ad1cd5
		https://source.foundries.io/factories/andy-corp/meta-subscriber-overrides.git/commit/?id=46d479f43ff1c0f6a75c1d1d9ef94156c1cc5377
		https://source.foundries.io/factories/andy-corp/containers.git/commit/?id=cb7544bb3c9b2b9e5e1b16a217b5c3a756fbbe4b

	App            HASH
	-------------  ----
	shellhttpd     4a3f0b4ee0bdbded9632f97f171d90c46a77ee2bc497ccfb1670a869e3e6833e
	code-server    ba46608bcb82bf7489b4b4786298f88930cfed1d6ddbc65b39efc005a3b4b73f
	homelab        a485df077640f8c39425f63ad0d3986593f849dc3c1942f0f1037a336a12aee7
	homeassistant  bafdec9c3be57056429fa1af4b3c45737bfce67fcd35c95b9b4ed421ac78d8cf
	fiotest        035fccbb398ef23f6e6a16fa2325b0439fec67868b741767e10dc9fb18f8c4ac
	ssh-container  fe68bbab22b64eaa66070dcc039f6943e1a8583fd66c4942605887b7324165cd
~~~