### PR TITLE
Fix bug in targets prune

### DIFF
--- a/subcommands/targets/prune.go
+++ b/subcommands/targets/prune.go
@@ -86,7 +86,8 @@ func doPrune(cmd *cobra.Command, args []string) {
 					fmt.Printf("Unable to decode target name: %s\n", name)
 					os.Exit(1)
 				}
-				verI, err := strconv.Atoi(parts[1])
+				custom, _ := api.TargetCustom(targets[name])
+				verI, err := strconv.Atoi(custom.Version)
 				subcommands.DieNotNil(err)
 				vals, ok := versions[verI]
 				if ok {


### PR DESCRIPTION
Target names used to look like intel-corei7-64-lmp-38  but now they
can look like intel-corei7-64-lmp-38-master and
intel-corei7-64-lmp-38-production if a factory does advanced tagging.

This uses a more fool-proof approach for finding the version

Signed-off-by: Andy Doan <andy@foundries.io>