### PR TITLE
targets: Show origin target where applicable

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -232,6 +232,7 @@ type TufCustom struct {
 	ContainersSha  string                `json:"containers-sha,omitempty"`
 	LmpManifestSha string                `json:"lmp-manifest-sha,omitempty"`
 	OverridesSha   string                `json:"meta-subscriber-overrides-sha,omitempty"`
+	OrigUri        string                `json:"origUri,omitempty"`
 }
 
 // ota-tuf serializes root.json differently from Notary. The key representation

--- a/subcommands/targets/list.go
+++ b/subcommands/targets/list.go
@@ -19,9 +19,10 @@ import (
 )
 
 var (
-	listProd  bool
-	listRaw   bool
-	listByTag string
+	listProd    bool
+	listRaw     bool
+	listByTag   string
+	showColumns []string
 )
 
 // Represents the details we use for displaying a single OTA "build"
@@ -52,16 +53,36 @@ func (t byTargetKey) Less(i, j int) bool {
 	return verI < verJ
 }
 
+type column struct {
+	Formatter func(tl *targetListing) string
+}
+
+var Columns = map[string]column{
+	"version":      {func(tl *targetListing) string { return strconv.Itoa(tl.version) }},
+	"tags":         {func(tl *targetListing) string { return strings.Join(tl.tags, ",") }},
+	"apps":         {func(tl *targetListing) string { return strings.Join(tl.apps, ",") }},
+	"hardware-ids": {func(tl *targetListing) string { return strings.Join(tl.hardwareIds, ",") }},
+	"origin":       {func(tl *targetListing) string { return tl.origin }},
+}
+
 func init() {
+	var defCols = []string{"version", "tags", "apps", "origin"}
+	allCols := make([]string, 0, len(Columns))
+	for k := range Columns {
+		allCols = append(allCols, k)
+	}
+	sort.Strings(allCols)
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List targets.",
 		Run:   doList,
+		Long:  "Available columns for display:\n\n  * " + strings.Join(allCols, "\n  * "),
 	}
 	cmd.AddCommand(listCmd)
 	listCmd.Flags().BoolVarP(&listRaw, "raw", "r", false, "Print raw targets.json")
 	listCmd.Flags().BoolVarP(&listProd, "production", "", false, "Show the production version targets.json")
 	listCmd.Flags().StringVarP(&listByTag, "by-tag", "", "", "Only list targets that match the given tag")
+	listCmd.Flags().StringSliceVarP(&showColumns, "columns", "", defCols, "Specify which columns to display")
 }
 
 func doList(cmd *cobra.Command, args []string) {
@@ -158,18 +179,25 @@ func doList(cmd *cobra.Command, args []string) {
 	}
 
 	t := tabby.New()
-	t.AddHeader("VERSION", "TAGS", "APPS", "HARDWARE IDs", "ORIGIN")
+	var cols = make([]interface{}, len(showColumns))
+	for idx, c := range showColumns {
+		if _, ok := Columns[c]; !ok {
+			fmt.Println("ERROR: Invalid column name:", c)
+			os.Exit(1)
+		}
+		cols[idx] = strings.ToUpper(c)
+	}
+	t.AddHeader(cols...)
+	row := make([]interface{}, len(showColumns))
 
 	sort.Sort(byTargetKey(keys))
 	for _, key := range keys {
 		l := listing[key]
-		sort.Strings(l.tags)
-		sort.Strings(l.apps)
-		sort.Strings(l.hardwareIds)
-		tags := strings.Join(l.tags, ",")
-		apps := strings.Join(l.apps, ",")
-		hwids := strings.Join(l.hardwareIds, ",")
-		t.AddLine(l.version, tags, apps, hwids, l.origin)
+		for idx, col := range showColumns {
+			col := Columns[col]
+			row[idx] = col.Formatter(l)
+		}
+		t.AddLine(row...)
 	}
 	t.Print()
 }

--- a/subcommands/targets/list.go
+++ b/subcommands/targets/list.go
@@ -27,11 +27,14 @@ var (
 
 // Represents the details we use for displaying a single OTA "build"
 type targetListing struct {
-	version     int
-	hardwareIds []string
-	tags        []string
-	apps        []string
-	origin      string
+	version      int
+	hardwareIds  []string
+	tags         []string
+	apps         []string
+	origin       string
+	manifestSha  string
+	overridesSha string
+	containerSha string
 }
 
 type byTargetKey []string
@@ -58,11 +61,14 @@ type column struct {
 }
 
 var Columns = map[string]column{
-	"version":      {func(tl *targetListing) string { return strconv.Itoa(tl.version) }},
-	"tags":         {func(tl *targetListing) string { return strings.Join(tl.tags, ",") }},
-	"apps":         {func(tl *targetListing) string { return strings.Join(tl.apps, ",") }},
-	"hardware-ids": {func(tl *targetListing) string { return strings.Join(tl.hardwareIds, ",") }},
-	"origin":       {func(tl *targetListing) string { return tl.origin }},
+	"version":        {func(tl *targetListing) string { return strconv.Itoa(tl.version) }},
+	"tags":           {func(tl *targetListing) string { return strings.Join(tl.tags, ",") }},
+	"apps":           {func(tl *targetListing) string { return strings.Join(tl.apps, ",") }},
+	"hardware-ids":   {func(tl *targetListing) string { return strings.Join(tl.hardwareIds, ",") }},
+	"origin":         {func(tl *targetListing) string { return tl.origin }},
+	"manifest-sha":   {func(tl *targetListing) string { return tl.manifestSha }},
+	"overrides-sha":  {func(tl *targetListing) string { return tl.overridesSha }},
+	"containers-sha": {func(tl *targetListing) string { return tl.containerSha }},
 }
 
 func init() {
@@ -169,11 +175,14 @@ func doList(cmd *cobra.Command, args []string) {
 				origin = parts[len(parts)-1]
 			}
 			listing[key] = &targetListing{
-				version:     ver,
-				hardwareIds: custom.HardwareIds,
-				tags:        custom.Tags,
-				apps:        apps,
-				origin:      origin,
+				version:      ver,
+				hardwareIds:  custom.HardwareIds,
+				tags:         custom.Tags,
+				apps:         apps,
+				origin:       origin,
+				manifestSha:  custom.LmpManifestSha,
+				overridesSha: custom.OverridesSha,
+				containerSha: custom.ContainersSha,
 			}
 		}
 	}

--- a/subcommands/targets/list.go
+++ b/subcommands/targets/list.go
@@ -30,6 +30,7 @@ type targetListing struct {
 	hardwareIds []string
 	tags        []string
 	apps        []string
+	origin      string
 }
 
 type byTargetKey []string
@@ -141,17 +142,23 @@ func doList(cmd *cobra.Command, args []string) {
 			}
 			sort.Strings(apps)
 			keys = append(keys, key)
+			origin := ""
+			if len(custom.OrigUri) > 0 {
+				parts := strings.Split(custom.OrigUri, "/")
+				origin = parts[len(parts)-1]
+			}
 			listing[key] = &targetListing{
 				version:     ver,
 				hardwareIds: custom.HardwareIds,
 				tags:        custom.Tags,
 				apps:        apps,
+				origin:      origin,
 			}
 		}
 	}
 
 	t := tabby.New()
-	t.AddHeader("VERSION", "TAGS", "APPS", "HARDWARE IDs")
+	t.AddHeader("VERSION", "TAGS", "APPS", "HARDWARE IDs", "ORIGIN")
 
 	sort.Sort(byTargetKey(keys))
 	for _, key := range keys {
@@ -162,7 +169,7 @@ func doList(cmd *cobra.Command, args []string) {
 		tags := strings.Join(l.tags, ",")
 		apps := strings.Join(l.apps, ",")
 		hwids := strings.Join(l.hardwareIds, ",")
-		t.AddLine(l.version, tags, apps, hwids)
+		t.AddLine(l.version, tags, apps, hwids, l.origin)
 	}
 	t.Print()
 }

--- a/subcommands/targets/show.go
+++ b/subcommands/targets/show.go
@@ -70,8 +70,12 @@ func doShow(cmd *cobra.Command, args []string) {
 			fmt.Printf("CI:\thttps://app.foundries.io/factories/%s/targets/%s/\n", factory, target.Version)
 		}
 		fmt.Println("\n## Target:", targetName)
-		fmt.Printf("\tTags:        %s\n", strings.Join(target.Tags, ","))
-		fmt.Printf("\tOSTree Hash: %s\n", hash)
+		fmt.Printf("\tTags:          %s\n", strings.Join(target.Tags, ","))
+		fmt.Printf("\tOSTree Hash:   %s\n", hash)
+		if len(target.OrigUri) > 0 {
+			parts := strings.Split(target.OrigUri, "/")
+			fmt.Printf("\tOrigin Target: %s\n", parts[len(parts)-1])
+		}
 		fmt.Println()
 		fmt.Println("\tSource:")
 		if len(target.LmpManifestSha) > 0 {


### PR DESCRIPTION
The webui includes an "Origin Target" which can be quite handy when trying to debug factory targets. This adds the same type functionality. It also lets users customize what columns to show when listing targets.