### PR TITLE
client: Make better error message for waves-init

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -1444,7 +1444,25 @@ func (a *Api) FactoryCreateWave(factory string, wave *WaveCreate) error {
 		return err
 	}
 
-	_, err = a.Post(url, data)
+	type WaveErr struct {
+		Message string   `json:"message"`
+		Errors  []string `json:"errors"`
+	}
+	body, err := a.Post(url, data)
+	if err != nil && body != nil {
+		if herr := AsHttpError(err); herr != nil {
+			var werr WaveErr
+			if json.Unmarshal(*body, &werr) == nil {
+				herr.Message = werr.Message
+				if werr.Errors != nil {
+					for _, err := range werr.Errors {
+						herr.Message += "\n * " + err
+					}
+				}
+				herr.Message += "\n"
+			}
+		}
+	}
 	return err
 }
 


### PR DESCRIPTION
This API returns a pretty useful error response. Instead of running
`fioctl waves init -v` and parsing debug messages, you can get something
like:

$ fioctl waves init move-to-139-codeserver 139 production --keys /var/code/andy-corp/keys/offline-creds.tgz --source-tag production
ERROR: Failed to create a wave Targets validation failed
 * CI Target differs for target raspberrypi4-64-lmp-139-master: not present in a wave
 * CI Target differs for target intel-corei7-64-lmp-139-master: not present in a wave
 * intel-corei7-64-lmp-38-production and intel-corei7-64-lmp-38-master conflict with each other's hardwareIds: intel-corei7-64
 * intel-corei7-64-lmp-78-1 and intel-corei7-64-lmp-78 conflict with each other's hardwareIds: intel-corei7-64
 * intel-corei7-64-lmp-79-1 and intel-corei7-64-lmp-79 conflict with each other's hardwareIds: intel-corei7-64
 * raspberrypi4-64-lmp-38-production and raspberrypi4-64-lmp-38-master conflict with each other's hardwareIds: raspberrypi4-64
 * raspberrypi4-64-lmp-78-1 and raspberrypi4-64-lmp-78 conflict with each other's hardwareIds: raspberrypi4-64
 * raspberrypi4-64-lmp-79-1 and raspberrypi4-64-lmp-79 conflict with each other's hardwareIds: raspberrypi4-64

Signed-off-by: Andy Doan <andy@foundries.io>