### PR TITLE
Show devices as offline when last-seen is not set

### DIFF
--- a/subcommands/devices/list.go
+++ b/subcommands/devices/list.go
@@ -37,7 +37,7 @@ func statusFormatter(d *client.Device) string {
 	if len(d.Status) > 0 {
 		status = d.Status
 	}
-	if len(d.LastSeen) > 0 && !d.Online(deviceInactiveHours) {
+	if !d.Online(deviceInactiveHours) {
 		status = "OFFLINE"
 	}
 	return status


### PR DESCRIPTION
I have a bunch of synthetic devices which have never contacted our APIs.
And still all of them show as OK in the device list despite their last-seen is not set.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>