### PR TITLE
wireguard: Fixed typo in error message displayed

### DIFF
--- a/subcommands/devices/config_wireguard.go
+++ b/subcommands/devices/config_wireguard.go
@@ -144,7 +144,7 @@ func doConfigWireguard(cmd *cobra.Command, args []string) {
 		}
 		os.Exit(0)
 	} else if args[1] != "enable" && args[1] != "disable" {
-		fmt.Printf("Invalid argument: '%s'. Must be 'enabled' or 'disabled'\n", args[1])
+		fmt.Printf("Invalid argument: '%s'. Must be 'enable' or 'disable'\n", args[1])
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
The correct options are `enable` or `disable` but in the error message
it said `enabled` and `disabled`. That causes some confusion when giving
`enabled` as an argument which is wrong but then get the message it
would be a correct possible one.

Signed-off-by: Eric Bode <eric.bode@foundries.io>