### PR TITLE
keys: Check if file exists during initial rotation

### DIFF
--- a/subcommands/keys/rotate_root.go
+++ b/subcommands/keys/rotate_root.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -48,6 +49,10 @@ func doRotateRoot(cmd *cobra.Command, args []string) {
 	subcommands.DieNotNil(err)
 
 	if initialRotation {
+		if _, err := os.Stat(credsFile); err == nil {
+			subcommands.DieNotNil(errors.New("Destination file exists. Please make sure you aren't accidentally overwriting another factory's keys"))
+		}
+
 		key, err := api.TufRootFirstKey(factory)
 		subcommands.DieNotNil(err)
 


### PR DESCRIPTION
During initial key rotation make sure the file does not exist already as
it could happen that when you do the initial rotation for two different
factories you might accidentially overwrite a file.

Signed-off-by: Eric Bode <eric.bode@foundries.io>