### PR TITLE
Add configure-docker helper

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/foundriesio/fioctl/subcommands"
 	cfgcmd "github.com/foundriesio/fioctl/subcommands/config"
 	"github.com/foundriesio/fioctl/subcommands/devices"
+	"github.com/foundriesio/fioctl/subcommands/docker"
 	"github.com/foundriesio/fioctl/subcommands/keys"
 	"github.com/foundriesio/fioctl/subcommands/login"
 	"github.com/foundriesio/fioctl/subcommands/logout"
@@ -37,6 +38,15 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
+	if os.Args[0] == docker.DOCKER_CREDS_HELPER {
+		if len(os.Args) != 2 || os.Args[1] != "get" {
+			fmt.Printf("Usage: %s get\n", os.Args[0])
+			os.Exit(1)
+		}
+		initConfig()
+		os.Exit(docker.RunCredsHelper())
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -53,6 +63,7 @@ func init() {
 
 	rootCmd.AddCommand(cfgcmd.NewCommand())
 	rootCmd.AddCommand(devices.NewCommand())
+	rootCmd.AddCommand(docker.NewCommand())
 	rootCmd.AddCommand(keys.NewCommand())
 	rootCmd.AddCommand(login.NewCommand())
 	rootCmd.AddCommand(logout.NewCommand())

--- a/subcommands/docker/cmd.go
+++ b/subcommands/docker/cmd.go
@@ -1,0 +1,129 @@
+package docker
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+
+	"github.com/foundriesio/fioctl/subcommands"
+	"github.com/mitchellh/go-homedir"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const DOCKER_CREDS_HELPER = "docker-credential-fio"
+
+var (
+	dockerConfigFile string
+	helperPath       string
+)
+
+func NewCommand() *cobra.Command {
+	path, err := exec.LookPath("docker")
+	subcommands.DieNotNil(err, "Docker not found on system")
+	helperPath = filepath.Dir(path)
+
+	dockerConfigFile = dockerConfigPath()
+
+	cmd := &cobra.Command{
+		Use:   "configure-docker",
+		Short: "Configure a hub.foundries.io Docker credential helper",
+		Long: `Configure a Docker credential helper that allows Docker to access
+access hub.foundries.io.
+
+This command will likely need to be run as root. It creates a symlink,
+docker-credential-fio, in the same directory as the docker client binary.
+
+NOTE: The credentials will need the "containers:read" scope to work with Docker`,
+		Run: doDockerCreds,
+	}
+	cmd.Flags().StringVarP(&helperPath, "creds-path", "", helperPath, "Path to install credential helper")
+	cmd.Flags().StringVarP(&dockerConfigFile, "docker-config", "", dockerConfigFile, "Docker config file to update")
+	return cmd
+}
+
+func findSelf() string {
+	self := os.Args[0]
+	if !filepath.IsAbs(self) {
+		logrus.Debugf("Looking up path to %s", self)
+		var err error
+		self, err = exec.LookPath(self)
+		subcommands.DieNotNil(err)
+		self, err = filepath.Abs(self)
+		subcommands.DieNotNil(err)
+	}
+	return filepath.Clean(self)
+}
+
+func dockerConfigPath() string {
+	sudoer := os.Getenv("SUDO_USER")
+	if len(sudoer) > 0 {
+		u, err := user.Lookup(sudoer)
+		subcommands.DieNotNil(err)
+		return filepath.Join(u.HomeDir, ".docker/config.json")
+	}
+	path, err := homedir.Expand("~/.docker/config.json")
+	subcommands.DieNotNil(err)
+	return path
+}
+
+func doDockerCreds(cmd *cobra.Command, args []string) {
+	self := findSelf()
+
+	var config map[string]interface{}
+	bytes, err := ioutil.ReadFile(dockerConfigFile)
+	if os.IsNotExist(err) {
+		dockerConfig := filepath.Dir(dockerConfigFile)
+		if _, err := os.Stat(filepath.Dir(dockerConfig)); os.IsNotExist(err) {
+			fmt.Println("Creating docker config directory:", dockerConfig)
+			subcommands.DieNotNil(os.Mkdir(dockerConfig, 0o755))
+		}
+		config = make(map[string]interface{})
+	} else {
+		subcommands.DieNotNil(json.Unmarshal(bytes, &config))
+	}
+
+	helpers, ok := config["credHelpers"]
+	if !ok {
+		config["credHelpers"] = map[string]string{
+			"hub.foundries.io": "fio",
+		}
+	} else {
+		helpers.(map[string]interface{})["hub.foundries.io"] = "fio"
+	}
+
+	configBytes, err := json.MarshalIndent(config, "", "  ")
+	subcommands.DieNotNil(err)
+
+	dst := filepath.Join(helperPath, DOCKER_CREDS_HELPER)
+	fmt.Println("Symlinking", self, "to", dst)
+	subcommands.DieNotNil(os.Symlink(self, dst))
+
+	fmt.Println("Adding hub.foundries.io helper to", dockerConfigFile)
+	subcommands.DieNotNil(ioutil.WriteFile(dockerConfigFile, configBytes, 0o600))
+}
+
+func RunCredsHelper() int {
+	if subcommands.Config.ClientCredentials.ClientSecret == "" {
+		msg := "ERROR: Your fioctl configuration does not appear to include oauth2 credentials. Please run `fioctl login` to configure and then try again.\n"
+		os.Stderr.WriteString(msg)
+		os.Exit(1)
+	}
+	subcommands.Login(NewCommand()) // Ensure a fresh oauth2 access token
+	creds := struct {
+		Username string
+		Secret   string
+	}{
+		Username: "<token>",
+		Secret:   subcommands.Config.ClientCredentials.AccessToken,
+	}
+
+	bytes, err := json.Marshal(creds)
+	subcommands.DieNotNil(err)
+	os.Stdout.Write(bytes)
+	return 0
+}


### PR DESCRIPTION
This allows you to do:

 sudo fioctl configure-docker

It will create a symlink from fioctl->/usr/bin/docker-credential-fio
and update your docker config with the helper. After that, docker
commands "just work".

Signed-off-by: Andy Doan <andy@foundries.io>