### PR TITLE
fix: update credentials dashboard url

### DIFF
--- a/subcommands/login/cmd.go
+++ b/subcommands/login/cmd.go
@@ -69,7 +69,7 @@ func promptForCreds() (string, string) {
 	scanner := bufio.NewScanner(os.Stdin)
 
 	fmt.Print("Please visit:\n\n")
-	fmt.Print("  https://app.foundries.io/settings/tokens/\n\n")
+	fmt.Print("  https://app.foundries.io/settings/credentials/\n\n")
 	fmt.Print("and create a new \"Application Credential\" to provide inputs below.\n\n")
 	fmt.Print("Client ID: ")
 	scanner.Scan()


### PR DESCRIPTION
  * Due to a new layout of the settings pages,
    application credentials now have their own
    dedicated page.

Signed-off-by: Milo Casagrande <milo@foundries.io>