### PR TITLE
Don't exit with error when config unchanged

### DIFF
--- a/subcommands/common_config.go
+++ b/subcommands/common_config.go
@@ -210,8 +210,8 @@ func SetUpdatesConfig(opts *SetUpdatesConfigOptions, reportedTag string, reporte
 	}
 
 	if !changed {
-		DieNotNil(fmt.Errorf(
-			"No changes found. Device is already configured with the specified options."))
+		fmt.Println("No changes found. Device is already configured with the specified options.")
+		os.Exit(0)
 	}
 
 	newToml, err := sota.ToTomlString()


### PR DESCRIPTION
Customer reported issue. They found this to be confusing/concerning:

 $ fioctl devices config updates --tags tutorial ashitaka
 ERROR: No changes found. Device is already configured with the specified options.
 (exit code 1)

The suggestion was to exit with:

 OK: No changes found. Device is already configured with the specified options.

I wasn't sure the "OK:" fit in with the rest of our commands, so I've
elected to just print the message and exit(0).

Signed-off-by: Andy Doan <andy@foundries.io>