### PR TITLE
keys: Include a changelog for root key rotation

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -278,11 +278,17 @@ func (k AtsKey) KeyID() (string, error) {
 	return fmt.Sprintf("%x", sha256.Sum256(bytes)), nil
 }
 
+type RootChangeReason struct {
+	PolisId   string    `json:"polis-id"`
+	Message   string    `json:"message"`
+	Timestamp time.Time `json:"timestamp"`
+}
 type AtsRootMeta struct {
 	tuf.SignedCommon
 	Consistent bool                           `json:"consistent_snapshot"`
 	Keys       map[string]AtsKey              `json:"keys"`
 	Roles      map[tuf.RoleName]*tuf.RootRole `json:"roles"`
+	Reason     *RootChangeReason              `json:"x-changelog,omitempty"`
 }
 
 type AtsTufRoot struct {


### PR DESCRIPTION
This change includes details for who/when/why root keys were rotated.
The backend API will verify this before committing the change.
Specifically:

 * polis-id *must* be ID of the user making the change
 * timestamp *must* be within 5 minutes of our clocks

Signed-off-by: Andy Doan <andy@foundries.io>