### PR TITLE
Add a hidden "factories" subcommand

### DIFF
--- a/client/foundries_factories.go
+++ b/client/foundries_factories.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"encoding/json"
+)
+
+type Factory struct {
+	Name string `json:"name"`
+	Id   string `json:"reposerver-id"`
+}
+
+func (a *Api) FactoriesList(admin bool) ([]Factory, error) {
+	url := a.serverUrl + "/ota/factories/"
+	if admin {
+		url += "?admin=1"
+	}
+	body, err := a.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	var factories []Factory
+	err = json.Unmarshal(*body, &factories)
+	return factories, err
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/foundriesio/fioctl/subcommands/devices"
 	"github.com/foundriesio/fioctl/subcommands/docker"
 	"github.com/foundriesio/fioctl/subcommands/events"
+	"github.com/foundriesio/fioctl/subcommands/factories"
 	"github.com/foundriesio/fioctl/subcommands/keys"
 	"github.com/foundriesio/fioctl/subcommands/login"
 	"github.com/foundriesio/fioctl/subcommands/logout"
@@ -66,6 +67,7 @@ func init() {
 	rootCmd.AddCommand(devices.NewCommand())
 	rootCmd.AddCommand(docker.NewCommand())
 	rootCmd.AddCommand(events.NewCommand())
+	rootCmd.AddCommand(factories.NewCommand())
 	rootCmd.AddCommand(keys.NewCommand())
 	rootCmd.AddCommand(login.NewCommand())
 	rootCmd.AddCommand(logout.NewCommand())

--- a/subcommands/factories/cmd.go
+++ b/subcommands/factories/cmd.go
@@ -1,0 +1,38 @@
+package factories
+
+import (
+	"github.com/cheynewallace/tabby"
+	"github.com/foundriesio/fioctl/client"
+	"github.com/foundriesio/fioctl/subcommands"
+	"github.com/spf13/cobra"
+)
+
+var (
+	api   *client.Api
+	admin bool
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "factories",
+		Short:  "List factories a user is a member of.",
+		Hidden: true, // Only useful support work
+		Run:    doFactories,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			api = subcommands.Login(cmd)
+		},
+	}
+	cmd.Flags().BoolVarP(&admin, "admin", "", false, "Show all factories")
+	return cmd
+}
+
+func doFactories(cmd *cobra.Command, args []string) {
+	factories, err := api.FactoriesList(admin)
+	subcommands.DieNotNil(err)
+	t := tabby.New()
+	t.AddHeader("NAME", "ID")
+	for _, f := range factories {
+		t.AddLine(f.Name, f.Id)
+	}
+	t.Print()
+}


### PR DESCRIPTION
I run `fioctl get https://api.foundries.io/ota/factories/` about 12
times a week looking for the reposerver id value. It's nothing a normal
user needs, but it's easy enough to add in a way that makes customer
support a little easier.

Signed-off-by: Andy Doan <andy@foundries.io>