### PR TITLE
targets: Stop root meta fetching if 404 received

### DIFF
--- a/subcommands/targets/offline-update.go
+++ b/subcommands/targets/offline-update.go
@@ -162,13 +162,8 @@ func downloadTufRepo(factory string, tag string, prod bool, dstDir string) error
 		metadataFileName := fmt.Sprintf("%d.root.json", ver)
 		err := downloadMetadataFile(metadataFileName)
 		if err != nil {
-			httpErr := client.AsHttpError(err)
-			if httpErr != nil {
-				// TODO: Fix an issue in ota-lite that returns 500 for non-existing non-prod N.root.json,
-				// and then remove 500 check here
-				if httpErr.Response.StatusCode != 404 && httpErr.Response.StatusCode != 500 {
-					return err
-				}
+			if httpErr := client.AsHttpError(err); httpErr != nil && httpErr.Response.StatusCode == 404 {
+				// if 404 received for N.root.json, then stop downloading root metadata versions
 				break
 			}
 			return err


### PR DESCRIPTION
Remove stopping of root meta fetching if 500 is received.
The issue in ota-lite was fixed so we should stop the fetch only if 404
is received. Any other response status codes are considered as errors.

Signed-off-by: Mike <mike.sul@foundries.io>