### PR TITLE
subcommands: Fix nil pointer issue in ca-show

### DIFF
--- a/subcommands/keys/ca_show.go
+++ b/subcommands/keys/ca_show.go
@@ -7,6 +7,7 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -106,6 +107,11 @@ func extKeyUsage(ext []x509.ExtKeyUsage) string {
 func prettyPrint(cert string) {
 	for len(cert) > 0 {
 		block, remaining := pem.Decode([]byte(cert))
+		if block == nil {
+			// could be excessive whitespace
+			cert = strings.TrimSpace(string(remaining))
+			continue
+		}
 		cert = string(remaining)
 		c, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {


### PR DESCRIPTION
The `keys ca show --pretty` has a null pointer issue when users have
run `keys ca update` with a file that has a bunch of trailing
whitespace. This detects that situation and prevents the crash.

Signed-off-by: Andy Doan <andy@foundries.io>