### PR TITLE
devices: Show App states if present

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -117,6 +117,32 @@ type DeviceGroup struct {
 	CreatedAt   string `json:"created-at"`
 }
 
+type AppServiceState struct {
+	Name     string `json:"name"`
+	Hash     string `json:"hash"`
+	State    string `json:"state"`
+	Status   string `json:"status"`
+	Health   string `json:"health"`
+	ImageUri string `json:"image"`
+	Logs     string `json:"logs"`
+}
+
+type AppState struct {
+	Services []AppServiceState `json:"services"`
+	State    string            `json:"state"`
+	Uri      string            `json:"uri"`
+}
+
+type AppsState struct {
+	Ostree     string              `json:"ostree"`
+	DeviceTime string              `json:"deviceTime"`
+	Apps       map[string]AppState `json:"apps,omitempty"`
+}
+
+type AppsStates struct {
+	States []AppsState `json:"apps-states"`
+}
+
 type Device struct {
 	Uuid          string           `json:"uuid"`
 	Name          string           `json:"name"`
@@ -145,6 +171,7 @@ type Device struct {
 		TargetName string `json:"target-name"`
 		HardwareId string `json:"hardware-id"`
 	} `json:"secondary-ecus"`
+	AppsState *AppsState `json:"apps-state,omitempty"`
 }
 
 type DeviceList struct {
@@ -851,6 +878,21 @@ func (a *Api) DeviceDeleteConfig(factory, device, filename string) error {
 	logrus.Debugf("Deleting config file: %s", url)
 	_, err := a.Delete(url, nil)
 	return err
+}
+
+func (a *Api) DeviceGetAppsStates(factory, device string) (*AppsStates, error) {
+	url := a.serverUrl + "/ota/devices/" + device + "/apps-states/?factory=" + factory
+	body, err := a.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	states := AppsStates{}
+	err = json.Unmarshal(*body, &states)
+	if err != nil {
+		return nil, err
+	}
+	return &states, nil
 }
 
 func (a *Api) FactoryCreateConfig(factory string, cfg ConfigCreateRequest) error {

--- a/subcommands/devices/apps_states.go
+++ b/subcommands/devices/apps_states.go
@@ -1,0 +1,72 @@
+package devices
+
+import (
+	"fmt"
+	"github.com/foundriesio/fioctl/client"
+	"github.com/foundriesio/fioctl/subcommands"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	asListLimit int
+)
+
+func init() {
+	appsStatesCmd := &cobra.Command{
+		Use:   "apps-states <name>",
+		Short: "List states of Apps reported by a device",
+		Run:   doListStates,
+		Args:  cobra.ExactArgs(1),
+	}
+	cmd.AddCommand(appsStatesCmd)
+	appsStatesCmd.Flags().IntVarP(&asListLimit, "limit", "n", 1, "Limit the number of Apps states to display.")
+}
+
+func doListStates(cmd *cobra.Command, args []string) {
+	factory := viper.GetString("factory")
+	states, err := api.DeviceGetAppsStates(factory, args[0])
+	subcommands.DieNotNil(err)
+
+	printAppsState := func(appsState map[string]client.AppState, stateFilter string, filterIn bool) {
+		for name, state := range appsState {
+			if len(stateFilter) > 0 {
+				if filterIn && state.State != stateFilter {
+					continue
+				}
+				if !filterIn && state.State == stateFilter {
+					continue
+				}
+			}
+			if len(state.Uri) > 0 {
+				fmt.Printf("\t%s\t%s\n", name, state.Uri)
+			} else {
+				fmt.Printf("\t%s\n", name)
+			}
+			for _, srv := range state.Services {
+				fmt.Printf("\t\t%s:\n", srv.Name)
+				fmt.Printf("\t\t\tURI:\t%s\n", srv.ImageUri)
+				fmt.Printf("\t\t\tHash:\t%s\n", srv.Hash)
+				fmt.Printf("\t\t\tHealth:\t%s\n", srv.Health)
+				fmt.Printf("\t\t\tState:\t%s\n", srv.State)
+				fmt.Printf("\t\t\tStatus:\t%s\n", srv.Status)
+				if len(srv.Logs) > 0 {
+					fmt.Printf("\t\t\tLogs:\t%s\n", srv.Logs)
+				}
+			}
+			fmt.Println()
+		}
+	}
+	for indx, s := range states.States {
+		if indx >= asListLimit {
+			break
+		}
+		fmt.Printf("Time:\t%s\n", s.DeviceTime)
+		fmt.Printf("Hash:\t%s\n", s.Ostree)
+		fmt.Println("Unhealthy Apps:")
+		printAppsState(s.Apps, "healthy", false)
+		fmt.Println("Healthy Apps:")
+		printAppsState(s.Apps, "healthy", true)
+		fmt.Println()
+	}
+}

--- a/subcommands/devices/show.go
+++ b/subcommands/devices/show.go
@@ -64,6 +64,19 @@ func doShow(cmd *cobra.Command, args []string) {
 	if len(device.CurrentUpdate) > 0 {
 		fmt.Printf("Update Id:\t%s\n", device.CurrentUpdate)
 	}
+	if device.AppsState != nil && device.AppsState.Apps != nil {
+		var healthyApps []string
+		var unhealthyApps []string
+		for a, s := range device.AppsState.Apps {
+			if s.State == "healthy" {
+				healthyApps = append(healthyApps, a)
+			} else {
+				unhealthyApps = append(unhealthyApps, a)
+			}
+		}
+		fmt.Printf("Healthy Apps:\t%s\n", strings.Join(healthyApps, ","))
+		fmt.Printf("Unhealthy Apps:\t%s\n", strings.Join(unhealthyApps, ","))
+	}
 	if device.Network != nil {
 		fmt.Println("Network Info:")
 		fmt.Printf("\tHostname:\t%s\n", device.Network.Hostname)


### PR DESCRIPTION
- Add printing of App states if present in the device json returned from
  ota-lite.
- By default, just a state summary is printed for each App. If a new
  flag `--appinfo` is specified then detail information about each App
  is output.

Signed-off-by: Mike <mike.sul@foundries.io>