### PR TITLE
Indent app state logs

### DIFF
--- a/subcommands/devices/apps_states.go
+++ b/subcommands/devices/apps_states.go
@@ -2,6 +2,8 @@ package devices
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/foundriesio/fioctl/client"
 	"github.com/foundriesio/fioctl/subcommands"
 	"github.com/spf13/cobra"
@@ -51,7 +53,10 @@ func doListStates(cmd *cobra.Command, args []string) {
 				fmt.Printf("\t\t\tState:\t%s\n", srv.State)
 				fmt.Printf("\t\t\tStatus:\t%s\n", srv.Status)
 				if len(srv.Logs) > 0 {
-					fmt.Printf("\t\t\tLogs:\t%s\n", srv.Logs)
+					fmt.Println("\t\t\tLogs:")
+					for _, line := range strings.Split(srv.Logs, "\n") {
+						fmt.Printf("\t\t\t | %s\n", line)
+					}
 				}
 			}
 			fmt.Println()


### PR DESCRIPTION
This makes the logs for an unhealthy app appear indented with the app
like:
```
	nginx:
		URI:	nginx
		Hash:
		Health:	unhealthy
		State:	running
		Status:	Up About a minute (unhealthy)
		Logs:
		 | :2022/08/11 18:47:42 [notice] 1#1: start worker process 38
		 | :2022/08/11 18:47:42 [notice] 1#1: start worker process 39
		 | :2022/08/11 18:47:42 [notice] 1#1: start worker process 40
		 | :2022/08/11 18:47:42 [notice] 1#1: start worker process 41
		 | :2022/08/11 18:47:42 [notice] 1#1: start worker process 42
		 |
```
Signed-off-by: Andy Doan <andy@foundries.io>