### PR TITLE
fix(post): Post subcommand index error

### DIFF
--- a/subcommands/post.go
+++ b/subcommands/post.go
@@ -56,7 +56,7 @@ func doPost(cmd *cobra.Command, args []string) {
 		logrus.Debug("Reading post data from stdin")
 		dataBytes, err = io.ReadAll(os.Stdin)
 		DieNotNil(err)
-	} else if data[0] == '@' {
+	} else if len(data) > 0 && data[0] == '@' {
 		// read from file
 		dataFile := data[1:]
 		logrus.Debugf("Reading post data from %s", dataFile)


### PR DESCRIPTION
There was an indexing error because we check for '@' first but if you give an empty body `-d ""` it will fail with an index[0] lookup error.

Signed-off-by: Eric Bode <eric.bode@foundries.io>