### PR TITLE
Revert the TUF keyid field calculation to support garage-sign

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -16,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	canonical "github.com/docker/go/canonical/json"
 	"github.com/fatih/color"
 	"github.com/sirupsen/logrus"
 	tuf "github.com/theupdateframework/notary/tuf/data"
@@ -306,14 +304,6 @@ type AtsKeyVal struct {
 type AtsKey struct {
 	KeyType  string    `json:"keytype"`
 	KeyValue AtsKeyVal `json:"keyval"`
-}
-
-func (k AtsKey) KeyID() (string, error) {
-	bytes, err := canonical.MarshalCanonical(k)
-	if err != nil {
-		return "", nil
-	}
-	return fmt.Sprintf("%x", sha256.Sum256(bytes)), nil
 }
 
 type RootChangeReason struct {


### PR DESCRIPTION
We still use the garage-sign to sign targets; some of our customers also use it. So, we need to support the garage-sign required algorithm to generate the TUF key IDs. Which by the way differs a lot from the TUF specification.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>