### PR TITLE
Refactoring to prepare for the TUF updates feature

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -294,38 +294,6 @@ type TufCustom struct {
 	CreatedAt      string                `json:"createdAt,omitempty"`
 }
 
-// ota-tuf serializes root.json differently from Notary. The key representation
-// and signing algoritms differ slightly. These Ats* structs provide an
-// an implementation compatible with ota-tuf and libaktualizr.
-type AtsKeyVal struct {
-	Public  string `json:"public,omitempty"`
-	Private string `json:"private,omitempty"`
-}
-type AtsKey struct {
-	KeyType  string    `json:"keytype"`
-	KeyValue AtsKeyVal `json:"keyval"`
-}
-
-type RootChangeReason struct {
-	PolisId   string    `json:"polis-id"`
-	Message   string    `json:"message"`
-	Timestamp time.Time `json:"timestamp"`
-}
-type AtsRootMeta struct {
-	tuf.SignedCommon
-	Consistent bool                           `json:"consistent_snapshot"`
-	Keys       map[string]AtsKey              `json:"keys"`
-	Roles      map[tuf.RoleName]*tuf.RootRole `json:"roles"`
-	Reason     *RootChangeReason              `json:"x-changelog,omitempty"`
-}
-
-type AtsTufRoot struct {
-	// A non-standard targets-signatures field allows to make an atomic key rotation
-	TargetsSignatures map[string][]tuf.Signature `json:"targets-signatures,omitempty"`
-	Signatures        []tuf.Signature            `json:"signatures"`
-	Signed            AtsRootMeta                `json:"signed"`
-}
-
 type AtsTargetsMeta struct {
 	tuf.SignedCommon
 	Targets tuf.Files `json:"targets"`
@@ -1090,17 +1058,6 @@ func (a *Api) FactoryListDeviceGroup(factory string) (*[]DeviceGroup, error) {
 	return &resp.Groups, nil
 }
 
-func (a *Api) GetFoundriesTargetsKey(factory string) (*AtsKey, error) {
-	url := a.serverUrl + "/ota/factories/" + factory + "/ci-targets.pub"
-	body, err := a.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	key := AtsKey{}
-	err = json.Unmarshal(*body, &key)
-	return &key, err
-}
-
 func (a *Api) GetWireGuardIps(factory string) ([]WireGuardIp, error) {
 	url := a.serverUrl + "/ota/factories/" + factory + "/wireguard-ips/"
 	body, err := a.Get(url)
@@ -1110,56 +1067,6 @@ func (a *Api) GetWireGuardIps(factory string) ([]WireGuardIp, error) {
 	var ips []WireGuardIp
 	err = json.Unmarshal(*body, &ips)
 	return ips, err
-}
-
-func (a *Api) TufRootFirstKey(factory string) (*AtsKey, error) {
-	url := a.serverUrl + "/ota/factories/" + factory + "/first_root.sec"
-	body, err := a.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	root := AtsKey{}
-	err = json.Unmarshal(*body, &root)
-	return &root, err
-}
-
-func (a *Api) tufRootGet(factory string, prod bool, version int) (*AtsTufRoot, error) {
-	url := a.serverUrl + "/ota/repo/" + factory + "/api/v1/user_repo/"
-	if version > 0 {
-		url += fmt.Sprintf("%d.", version)
-	}
-	url += "root.json"
-	if prod {
-		url += "?production=1"
-	}
-	logrus.Debugf("Fetch root %s", url)
-	body, err := a.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	root := AtsTufRoot{}
-	err = json.Unmarshal(*body, &root)
-	return &root, err
-}
-func (a *Api) TufRootGet(factory string) (*AtsTufRoot, error) {
-	return a.tufRootGet(factory, false, -1)
-}
-func (a *Api) TufRootGetVer(factory string, version int) (*AtsTufRoot, error) {
-	return a.tufRootGet(factory, false, version)
-}
-func (a *Api) TufProdRootGet(factory string) (*AtsTufRoot, error) {
-	return a.tufRootGet(factory, true, -1)
-}
-func (a *Api) tufRootPost(factory string, prod bool, root []byte) (string, error) {
-	url := a.serverUrl + "/ota/repo/" + factory + "/api/v1/user_repo/root"
-	if prod {
-		url += "?production=1"
-	}
-	body, err := a.Post(url, root)
-	if body != nil {
-		return string(*body), err
-	}
-	return "", err
 }
 
 func (a *Api) TufMetadataGet(factory string, metadata string, tag string, prod bool) (*[]byte, error) {
@@ -1196,13 +1103,6 @@ func (a *Api) TufTargetMetadataRefresh(factory string, target string, tag string
 		return nil, err
 	}
 	return meta, nil
-}
-
-func (a *Api) TufRootPost(factory string, root []byte) (string, error) {
-	return a.tufRootPost(factory, false, root)
-}
-func (a *Api) TufProdRootPost(factory string, root []byte) (string, error) {
-	return a.tufRootPost(factory, true, root)
 }
 
 func (a *Api) TargetsListRaw(factory string) (*[]byte, error) {

--- a/client/foundries_tuf_root.go
+++ b/client/foundries_tuf_root.go
@@ -41,7 +41,7 @@ type AtsTufRoot struct {
 	Signed            AtsRootMeta                `json:"signed"`
 }
 
-func (a *Api) GetFoundriesTargetsKey(factory string) (*AtsKey, error) {
+func (a *Api) TufTargetsOnlineKey(factory string) (*AtsKey, error) {
 	url := a.serverUrl + "/ota/factories/" + factory + "/ci-targets.pub"
 	body, err := a.Get(url)
 	if err != nil {

--- a/client/foundries_tuf_root.go
+++ b/client/foundries_tuf_root.go
@@ -1,0 +1,115 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	tuf "github.com/theupdateframework/notary/tuf/data"
+)
+
+// ota-tuf serializes root.json differently from Notary. The key representation
+// and signing algoritms differ slightly. These Ats* structs provide an
+// an implementation compatible with ota-tuf and libaktualizr.
+type AtsKeyVal struct {
+	Public  string `json:"public,omitempty"`
+	Private string `json:"private,omitempty"`
+}
+type AtsKey struct {
+	KeyType  string    `json:"keytype"`
+	KeyValue AtsKeyVal `json:"keyval"`
+}
+
+type RootChangeReason struct {
+	PolisId   string    `json:"polis-id"`
+	Message   string    `json:"message"`
+	Timestamp time.Time `json:"timestamp"`
+}
+type AtsRootMeta struct {
+	tuf.SignedCommon
+	Consistent bool                           `json:"consistent_snapshot"`
+	Keys       map[string]AtsKey              `json:"keys"`
+	Roles      map[tuf.RoleName]*tuf.RootRole `json:"roles"`
+	Reason     *RootChangeReason              `json:"x-changelog,omitempty"`
+}
+
+type AtsTufRoot struct {
+	// A non-standard targets-signatures field allows to make an atomic key rotation
+	TargetsSignatures map[string][]tuf.Signature `json:"targets-signatures,omitempty"`
+	Signatures        []tuf.Signature            `json:"signatures"`
+	Signed            AtsRootMeta                `json:"signed"`
+}
+
+func (a *Api) GetFoundriesTargetsKey(factory string) (*AtsKey, error) {
+	url := a.serverUrl + "/ota/factories/" + factory + "/ci-targets.pub"
+	body, err := a.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	key := AtsKey{}
+	err = json.Unmarshal(*body, &key)
+	return &key, err
+}
+
+func (a *Api) TufRootFirstKey(factory string) (*AtsKey, error) {
+	url := a.serverUrl + "/ota/factories/" + factory + "/first_root.sec"
+	body, err := a.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	root := AtsKey{}
+	err = json.Unmarshal(*body, &root)
+	return &root, err
+}
+
+func (a *Api) TufRootGet(factory string) (*AtsTufRoot, error) {
+	return a.tufRootGet(factory, false, -1)
+}
+
+func (a *Api) TufRootGetVer(factory string, version int) (*AtsTufRoot, error) {
+	return a.tufRootGet(factory, false, version)
+}
+
+func (a *Api) TufProdRootGet(factory string) (*AtsTufRoot, error) {
+	return a.tufRootGet(factory, true, -1)
+}
+
+func (a *Api) TufRootPost(factory string, root []byte) (string, error) {
+	return a.tufRootPost(factory, false, root)
+}
+
+func (a *Api) TufProdRootPost(factory string, root []byte) (string, error) {
+	return a.tufRootPost(factory, true, root)
+}
+
+func (a *Api) tufRootGet(factory string, prod bool, version int) (*AtsTufRoot, error) {
+	url := a.serverUrl + "/ota/repo/" + factory + "/api/v1/user_repo/"
+	if version > 0 {
+		url += fmt.Sprintf("%d.", version)
+	}
+	url += "root.json"
+	if prod {
+		url += "?production=1"
+	}
+	logrus.Debugf("Fetch root %s", url)
+	body, err := a.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	root := AtsTufRoot{}
+	err = json.Unmarshal(*body, &root)
+	return &root, err
+}
+
+func (a *Api) tufRootPost(factory string, prod bool, root []byte) (string, error) {
+	url := a.serverUrl + "/ota/repo/" + factory + "/api/v1/user_repo/root"
+	if prod {
+		url += "?production=1"
+	}
+	body, err := a.Post(url, root)
+	if body != nil {
+		return string(*body), err
+	}
+	return "", err
+}

--- a/subcommands/common.go
+++ b/subcommands/common.go
@@ -1,6 +1,7 @@
 package subcommands
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/cheynewallace/tabby"
+	canonical "github.com/docker/go/canonical/json"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/shurcooL/go/indentwriter"
 	"github.com/sirupsen/logrus"
@@ -130,6 +132,20 @@ func Tabby(indent int, columns ...interface{}) *tabby.Tabby {
 		tab.AddHeader(columns...)
 	}
 	return tab
+}
+
+// Copied from canonical.MarshalIndent, but replaced the Marshal call with MarshalCanonical.
+func MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
+	b, err := canonical.MarshalCanonical(v)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	err = canonical.Indent(&buf, b, prefix, indent)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func AssertWritable(path string) {

--- a/subcommands/devices/show.go
+++ b/subcommands/devices/show.go
@@ -1,7 +1,6 @@
 package devices
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -103,7 +102,7 @@ func doShow(cmd *cobra.Command, args []string) {
 		}
 	}
 	if device.Hardware != nil {
-		b, err := json.MarshalIndent(device.Hardware, "\t", "  ")
+		b, err := subcommands.MarshalIndent(device.Hardware, "\t", "  ")
 		if err != nil {
 			fmt.Println("Unable to marshall hardware info: ", err)
 		}

--- a/subcommands/docker/cmd.go
+++ b/subcommands/docker/cmd.go
@@ -99,7 +99,7 @@ func doDockerCreds(cmd *cobra.Command, args []string) {
 		helpers.(map[string]interface{})["hub.foundries.io"] = "fio"
 	}
 
-	configBytes, err := json.MarshalIndent(config, "", "  ")
+	configBytes, err := subcommands.MarshalIndent(config, "", "  ")
 	subcommands.DieNotNil(err)
 
 	dst := filepath.Join(helperPath, DOCKER_CREDS_HELPER)

--- a/subcommands/keys/tuf_copy_targets.go
+++ b/subcommands/keys/tuf_copy_targets.go
@@ -47,7 +47,7 @@ func doCopyTargets(cmd *cobra.Command, args []string) {
 
 func createTargetsCreds(factory string, root client.AtsTufRoot, creds OfflineCreds) (OfflineCreds, error) {
 	targets := make(OfflineCreds)
-	onlinePub, err := api.GetFoundriesTargetsKey(factory)
+	onlinePub, err := api.TufTargetsOnlineKey(factory)
 	subcommands.DieNotNil(err)
 	for _, keyid := range root.Signed.Roles["targets"].KeyIDs {
 		pubkey := root.Signed.Keys[keyid].KeyValue.Public

--- a/subcommands/keys/tuf_copy_targets.go
+++ b/subcommands/keys/tuf_copy_targets.go
@@ -42,7 +42,7 @@ func doCopyTargets(cmd *cobra.Command, args []string) {
 
 	targetsCreds, err := createTargetsCreds(factory, *root, creds)
 	subcommands.DieNotNil(err)
-	SaveCreds(args[1], targetsCreds)
+	saveTufCreds(args[1], targetsCreds)
 }
 
 func createTargetsCreds(factory string, root client.AtsTufRoot, creds OfflineCreds) (OfflineCreds, error) {

--- a/subcommands/keys/tuf_resign_root.go
+++ b/subcommands/keys/tuf_resign_root.go
@@ -64,8 +64,8 @@ func doResignRoot(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Println("= Resigning root.json")
-	RemoveUnusedKeys(root)
-	subcommands.DieNotNil(SignRoot(root, *curPk))
+	removeUnusedTufKeys(root)
+	subcommands.DieNotNil(signTufRoot(root, *curPk))
 
 	bytes, err := json.MarshalIndent(root, "", "  ")
 	subcommands.DieNotNil(err)

--- a/subcommands/keys/tuf_resign_root.go
+++ b/subcommands/keys/tuf_resign_root.go
@@ -50,7 +50,7 @@ func doResignRoot(cmd *cobra.Command, args []string) {
 	root.Signed.Expires = time.Now().AddDate(1, 0, 0).UTC().Round(time.Second) // 1 year validity
 	root.Signed.Version += 1
 
-	curPk, err := findRoot(root, creds)
+	curPk, err := findTufRootSigner(root, creds)
 	subcommands.DieNotNil(err)
 	fmt.Println("= Current root:", curPk.Id)
 

--- a/subcommands/keys/tuf_resign_root.go
+++ b/subcommands/keys/tuf_resign_root.go
@@ -1,7 +1,6 @@
 package keys
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -67,7 +66,7 @@ func doResignRoot(cmd *cobra.Command, args []string) {
 	removeUnusedTufKeys(root)
 	subcommands.DieNotNil(signTufRoot(root, *curPk))
 
-	bytes, err := json.MarshalIndent(root, "", "  ")
+	bytes, err := subcommands.MarshalIndent(root, "", "  ")
 	subcommands.DieNotNil(err)
 
 	if dryRun {

--- a/subcommands/keys/tuf_rotate_offline_key.go
+++ b/subcommands/keys/tuf_rotate_offline_key.go
@@ -201,7 +201,7 @@ func doRotateOfflineKey(cmd *cobra.Command, args []string) {
 		subcommands.DieNotNil(err)
 	}
 
-	rootKey, err := findRoot(root, creds)
+	rootKey, err := findTufRootSigner(root, creds)
 	subcommands.DieNotNil(err)
 	signers = append(signers, *rootKey)
 	credsFileToSave := credsFile
@@ -213,7 +213,7 @@ func doRotateOfflineKey(cmd *cobra.Command, args []string) {
 		// 2. sign the new root.json with both the old and new root
 		subcommands.AssertWritable(credsFile)
 		fmt.Println("= Current root keyid:", rootKey.Id)
-		newKey, newCreds = swapRootKey(root, rootKey.Id, creds, keyType)
+		newKey, newCreds = swapRootKey(root, creds, keyType)
 		fmt.Println("= New root keyid:", newKey.Id)
 		signers = append(signers, *newKey)
 		if changeLog == "" {
@@ -249,7 +249,8 @@ func doRotateOfflineKey(cmd *cobra.Command, args []string) {
 		newKey, newCreds = replaceOfflineTargetsKey(root, onlineTargetsId, targetsCreds, keyType)
 		fmt.Println("= New target keyid:", newKey.Id)
 		fmt.Println("= Resigning prod targets")
-		subcommands.DieNotNil(resignProdTargets(factory, root, onlineTargetsId, newCreds))
+		root.TargetsSignatures, err = resignProdTargets(factory, root, onlineTargetsId, newCreds)
+		subcommands.DieNotNil(err)
 		if changeLog == "" {
 			changeLog = "Targets role offline key rotation, new keyid: " + newKey.Id
 		}
@@ -263,6 +264,7 @@ func doRotateOfflineKey(cmd *cobra.Command, args []string) {
 		Message:   changeLog,
 		Timestamp: time.Now(),
 	}
+	root.Signed.Version += 1
 	fmt.Println("= Resigning root.json")
 	subcommands.DieNotNil(signTufRoot(root, signers...))
 
@@ -313,24 +315,17 @@ Please run a hidden "fioctl keys tuf sync-prod-root %s" command to fix this.`, s
 }
 
 func swapRootKey(
-	root *client.AtsTufRoot, curid string, creds OfflineCreds, keyType TufKeyType,
+	root *client.AtsTufRoot, creds OfflineCreds, keyType TufKeyType,
 ) (*TufSigner, OfflineCreds) {
 	kp := genTufKeyPair(keyType)
 	root.Signed.Keys[kp.signer.Id] = kp.atsPub
 	root.Signed.Expires = time.Now().AddDate(1, 0, 0).UTC().Round(time.Second) // 1 year validity
 	root.Signed.Roles["root"].KeyIDs = []string{kp.signer.Id}
-	root.Signed.Version += 1
 
 	base := "tufrepo/keys/fioctl-root-" + kp.signer.Id
 	creds[base+".pub"] = kp.atsPubBytes
 	creds[base+".sec"] = kp.atsPrivBytes
 	return &kp.signer, creds
-}
-
-func findRoot(root *client.AtsTufRoot, creds OfflineCreds) (*TufSigner, error) {
-	kid := root.Signed.Roles["root"].KeyIDs[0]
-	pub := root.Signed.Keys[kid].KeyValue.Public
-	return FindSigner(kid, pub, creds)
 }
 
 func syncProdRoot(factory string, root *client.AtsTufRoot, creds, targetsCreds OfflineCreds) error {
@@ -374,7 +369,7 @@ func syncProdRoot(factory string, root *client.AtsTufRoot, creds, targetsCreds O
 		if err != nil {
 			return err
 		}
-		err = resignProdTargets(factory, root, onlineTargetsId, targetsCreds)
+		root.TargetsSignatures, err = resignProdTargets(factory, root, onlineTargetsId, targetsCreds)
 		if err != nil {
 			return err
 		}
@@ -410,7 +405,6 @@ func replaceOfflineTargetsKey(
 	root.Signed.Keys[kp.signer.Id] = kp.atsPub
 	root.Signed.Roles["targets"].KeyIDs = []string{onlineTargetsId, kp.signer.Id}
 	root.Signed.Roles["targets"].Threshold = 1
-	root.Signed.Version += 1
 
 	base := "tufrepo/keys/fioctl-targets-" + kp.signer.Id
 	creds[base+".pub"] = kp.atsPubBytes
@@ -420,12 +414,12 @@ func replaceOfflineTargetsKey(
 
 func resignProdTargets(
 	factory string, root *client.AtsTufRoot, onlineTargetsId string, creds OfflineCreds,
-) error {
+) (map[string][]tuf.Signature, error) {
 	targetsMap, err := api.ProdTargetsList(factory, false)
 	if err != nil {
-		return fmt.Errorf("Failed to fetch production targets: %w", err)
+		return nil, fmt.Errorf("Failed to fetch production targets: %w", err)
 	} else if targetsMap == nil {
-		return nil
+		return nil, nil
 	}
 
 	var signers []TufSigner
@@ -436,7 +430,7 @@ func resignProdTargets(
 		pub := root.Signed.Keys[kid].KeyValue.Public
 		signer, err := FindTufSigner(kid, pub, creds)
 		if err != nil {
-			return fmt.Errorf("Failed to find private key for %s: %w", kid, err)
+			return nil, fmt.Errorf("Failed to find private key for %s: %w", kid, err)
 		}
 		signers = append(signers, *signer)
 	}
@@ -445,14 +439,13 @@ func resignProdTargets(
 	for tag, targets := range targetsMap {
 		bytes, err := canonical.MarshalCanonical(targets.Signed)
 		if err != nil {
-			return fmt.Errorf("Failed to marshal targets for tag %s: %w", tag, err)
+			return nil, fmt.Errorf("Failed to marshal targets for tag %s: %w", tag, err)
 		}
 		signatures, err := SignTufMeta(bytes, signers...)
 		if err != nil {
-			return fmt.Errorf("Failed to re-sign targets for tag %s: %w", tag, err)
+			return nil, fmt.Errorf("Failed to re-sign targets for tag %s: %w", tag, err)
 		}
 		signatureMap[tag] = signatures
 	}
-	root.TargetsSignatures = signatureMap
-	return nil
+	return signatureMap, nil
 }

--- a/subcommands/keys/tuf_rotate_offline_key.go
+++ b/subcommands/keys/tuf_rotate_offline_key.go
@@ -392,7 +392,7 @@ func syncProdRoot(factory string, root *client.AtsTufRoot, creds, targetsCreds O
 }
 
 func findOnlineTargetsId(factory string, root client.AtsTufRoot) (string, error) {
-	onlinePub, err := api.GetFoundriesTargetsKey(factory)
+	onlinePub, err := api.TufTargetsOnlineKey(factory)
 	subcommands.DieNotNil(err)
 	for _, keyid := range root.Signed.Roles["targets"].KeyIDs {
 		pub := root.Signed.Keys[keyid].KeyValue.Public

--- a/subcommands/keys/tuf_show_root.go
+++ b/subcommands/keys/tuf_show_root.go
@@ -1,7 +1,6 @@
 package keys
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/foundriesio/fioctl/client"
@@ -47,7 +46,7 @@ func doShowRoot(cmd *cobra.Command, args []string) {
 		root, err = api.TufRootGet(factory)
 	}
 	subcommands.DieNotNil(err)
-	bytes, err := json.MarshalIndent(root, "", "  ")
+	bytes, err := subcommands.MarshalIndent(root, "", "  ")
 	subcommands.DieNotNil(err)
 	fmt.Println(string(bytes))
 }

--- a/subcommands/keys/tuf_utils.go
+++ b/subcommands/keys/tuf_utils.go
@@ -49,7 +49,7 @@ func ParseTufRoleNameOffline(s string) string {
 	return r
 }
 
-func genKeyId(key crypto.Signer) string {
+func genTufKeyId(key crypto.Signer) string {
 	// # This has to match the exact logic used by ota-tuf (required by garage-sign):
 	// https://github.com/foundriesio/ota-tuf/blob/fio-changes/libtuf/src/main/scala/com/advancedtelematic/libtuf/crypt/TufCrypto.scala#L66-L71
 	// It sets a keyid to a signature of the key's canonical DER encoding (same logic for all keys).
@@ -59,7 +59,7 @@ func genKeyId(key crypto.Signer) string {
 	return fmt.Sprintf("%x", sha256.Sum256(pubBytes))
 }
 
-func GenKeyPair(keyType TufKeyType) TufKeyPair {
+func genTufKeyPair(keyType TufKeyType) TufKeyPair {
 	keyTypeName := keyType.Name()
 	pk, err := keyType.GenerateKey()
 	subcommands.DieNotNil(err)
@@ -80,7 +80,7 @@ func GenKeyPair(keyType TufKeyType) TufKeyPair {
 	atsPubBytes, err := json.Marshal(pub)
 	subcommands.DieNotNil(err)
 
-	id := genKeyId(pk)
+	id := genTufKeyId(pk)
 
 	return TufKeyPair{
 		atsPriv:      priv,
@@ -95,7 +95,7 @@ func GenKeyPair(keyType TufKeyType) TufKeyPair {
 	}
 }
 
-func SignMeta(metaBytes []byte, signers ...TufSigner) ([]tuf.Signature, error) {
+func SignTufMeta(metaBytes []byte, signers ...TufSigner) ([]tuf.Signature, error) {
 	signatures := make([]tuf.Signature, len(signers))
 
 	for idx, signer := range signers {
@@ -121,12 +121,12 @@ func SignMeta(metaBytes []byte, signers ...TufSigner) ([]tuf.Signature, error) {
 	return signatures, nil
 }
 
-func SignRoot(root *client.AtsTufRoot, signers ...TufSigner) error {
+func signTufRoot(root *client.AtsTufRoot, signers ...TufSigner) error {
 	bytes, err := canonical.MarshalCanonical(root.Signed)
 	if err != nil {
 		return err
 	}
-	signatures, err := SignMeta(bytes, signers...)
+	signatures, err := SignTufMeta(bytes, signers...)
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func SignRoot(root *client.AtsTufRoot, signers ...TufSigner) error {
 	return nil
 }
 
-func SaveCreds(path string, creds OfflineCreds) {
+func saveTufCreds(path string, creds OfflineCreds) {
 	file, err := os.Create(path)
 	subcommands.DieNotNil(err)
 	defer file.Close()
@@ -156,7 +156,7 @@ func SaveCreds(path string, creds OfflineCreds) {
 	}
 }
 
-func SaveTempCreds(credsFile string, creds OfflineCreds) string {
+func saveTempTufCreds(credsFile string, creds OfflineCreds) string {
 	path := credsFile + ".tmp"
 	if _, err := os.Stat(path); err == nil {
 		subcommands.DieNotNil(fmt.Errorf(`Backup file exists: %s
@@ -165,7 +165,7 @@ Please move this file somewhere safe before re-running this command.`,
 			path,
 		))
 	}
-	SaveCreds(path, creds)
+	saveTufCreds(path, creds)
 	return path
 }
 
@@ -205,7 +205,7 @@ func GetOfflineCreds(credsFile string) (OfflineCreds, error) {
 	return files, nil
 }
 
-func FindSigner(keyid, pubkey string, creds OfflineCreds) (*TufSigner, error) {
+func FindTufSigner(keyid, pubkey string, creds OfflineCreds) (*TufSigner, error) {
 	pubkey = strings.TrimSpace(pubkey)
 	for k, v := range creds {
 		if strings.HasSuffix(k, ".pub") {
@@ -239,7 +239,7 @@ func FindSigner(keyid, pubkey string, creds OfflineCreds) (*TufSigner, error) {
 	return nil, fmt.Errorf("Can not find private key for: %s", pubkey)
 }
 
-func RemoveUnusedKeys(root *client.AtsTufRoot) {
+func removeUnusedTufKeys(root *client.AtsTufRoot) {
 	var inuse []string
 	for _, role := range root.Signed.Roles {
 		inuse = append(inuse, role.KeyIDs...)

--- a/subcommands/keys/tuf_utils.go
+++ b/subcommands/keys/tuf_utils.go
@@ -236,7 +236,13 @@ func FindTufSigner(keyid, pubkey string, creds OfflineCreds) (*TufSigner, error)
 			}
 		}
 	}
-	return nil, fmt.Errorf("Can not find private key for: %s", pubkey)
+	return nil, fmt.Errorf("Can not find private key for: %s", keyid)
+}
+
+func findTufRootSigner(root *client.AtsTufRoot, creds OfflineCreds) (*TufSigner, error) {
+	kid := root.Signed.Roles["root"].KeyIDs[0]
+	pub := root.Signed.Keys[kid].KeyValue.Public
+	return FindTufSigner(kid, pub, creds)
 }
 
 func removeUnusedTufKeys(root *client.AtsTufRoot) {

--- a/subcommands/targets/edit.go
+++ b/subcommands/targets/edit.go
@@ -35,7 +35,7 @@ func doEdit(cmd *cobra.Command, args []string) {
 	// Get raw json
 	targets, err := api.TargetsList(factory)
 	subcommands.DieNotNil(err)
-	orig, err := json.MarshalIndent(targets, "", "  ")
+	orig, err := subcommands.MarshalIndent(targets, "", "  ")
 	subcommands.DieNotNil(err)
 
 	// Create temp file to edit with

--- a/subcommands/targets/tag.go
+++ b/subcommands/targets/tag.go
@@ -1,7 +1,6 @@
 package targets
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -108,7 +107,7 @@ func doTag(cmd *cobra.Command, args []string) {
 	}
 
 	if dryRun {
-		data, err := json.MarshalIndent(updates, "  ", "  ")
+		data, err := subcommands.MarshalIndent(updates, "  ", "  ")
 		subcommands.DieNotNil(err)
 		fmt.Println(string(data))
 		return

--- a/subcommands/waves/init.go
+++ b/subcommands/waves/init.go
@@ -129,7 +129,7 @@ func doInitWave(cmd *cobra.Command, args []string) {
 func signTargets(meta []byte, factory string, offlineKeys keys.OfflineCreds) []tuf.Signature {
 	root, err := api.TufRootGet(factory)
 	subcommands.DieNotNil(err, "Failed to fetch root role")
-	onlinePub, err := api.GetFoundriesTargetsKey(factory)
+	onlinePub, err := api.TufTargetsOnlineKey(factory)
 	subcommands.DieNotNil(err, "Failed to fetch online targets public key")
 
 	signers := make([]keys.TufSigner, 0)

--- a/subcommands/waves/init.go
+++ b/subcommands/waves/init.go
@@ -138,7 +138,7 @@ func signTargets(meta []byte, factory string, offlineKeys keys.OfflineCreds) []t
 		if pub == onlinePub.KeyValue.Public {
 			continue
 		}
-		signer, err := keys.FindSigner(kid, pub, offlineKeys)
+		signer, err := keys.FindTufSigner(kid, pub, offlineKeys)
 		if err != nil {
 			subcommands.DieNotNil(err, fmt.Sprintf("Failed to find private key for %s", kid))
 		}
@@ -150,7 +150,7 @@ func signTargets(meta []byte, factory string, offlineKeys keys.OfflineCreds) []t
 Please, run "fioctl keys rotate-targets" in order to create offline targets keys.`))
 	}
 
-	signatures, err := keys.SignMeta(meta, signers...)
+	signatures, err := keys.SignTufMeta(meta, signers...)
 	subcommands.DieNotNil(err, "Failed to sign new targets")
 	return signatures
 }

--- a/subcommands/waves/init.go
+++ b/subcommands/waves/init.go
@@ -118,7 +118,7 @@ func doInitWave(cmd *cobra.Command, args []string) {
 		Targets: signed,
 	}
 	if dryRun {
-		payload, err := json.MarshalIndent(&wave, "", "  ")
+		payload, err := subcommands.MarshalIndent(&wave, "", "  ")
 		subcommands.DieNotNil(err, "Failed to marshal a wave")
 		fmt.Println(string(payload))
 	} else {

--- a/subcommands/waves/show.go
+++ b/subcommands/waves/show.go
@@ -1,7 +1,6 @@
 package waves
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
 
@@ -72,7 +71,7 @@ func doShowWave(cmd *cobra.Command, args []string) {
 
 	if showTargets {
 		fmt.Printf("Targets:\n")
-		data, _ := json.MarshalIndent(wave.Targets, "  ", "  ")
+		data, _ := subcommands.MarshalIndent(wave.Targets, "  ", "  ")
 		fmt.Println("  " + string(data))
 	}
 }


### PR DESCRIPTION
* extract TUF root client routines into a separate file;
* rename TUF related routines to hold Tuf prefix or suffix where applicable;
* make private all TUF related functions (which are not re-used outside the `subcommands/keys` package;
* use canonical MarshalIndent to output user-friendly JSON data in all commands;
* some other minor non-functional code cleanups.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>