### PR TITLE
Hotpatch: support the ota-lite generated Ed25519 keys

### DIFF
--- a/subcommands/keys/tuf_crypto.go
+++ b/subcommands/keys/tuf_crypto.go
@@ -118,14 +118,18 @@ func (t *tufKeyTypeEd25519) ParseKey(priv string) (crypto.Signer, error) {
 	if err != nil {
 		return nil, errors.New("Unable to parse Ed25519 private key HEX data")
 	}
-	if len(pk) != ed25519.PrivateKeySize {
+	switch len(pk) {
+	case ed25519.PrivateKeySize:
+		return ed25519.PrivateKey(pk), nil
+	case ed25519.SeedSize:
+		return ed25519.NewKeyFromSeed(pk), nil
+	default:
 		return nil, errors.New("Wrong Ed25519 private key size")
 	}
-	return ed25519.PrivateKey(pk), nil
 }
 
 func (t *tufKeyTypeEd25519) SaveKeyPair(key crypto.Signer) (priv, pub string, err error) {
-	priv = hex.EncodeToString([]byte(key.(ed25519.PrivateKey)))
+	priv = hex.EncodeToString(key.(ed25519.PrivateKey).Seed())
 	pub = hex.EncodeToString([]byte(key.Public().(ed25519.PublicKey)))
 	return
 }


### PR DESCRIPTION
It turns out that the Golang's native ed25519 package stores private keys in a custom way. In contrast, both Foundries.io and ota-community-edition store them in RFC 8032 compliant way.

The difference is that Golang concats the public key bytes to the end of private key bytes. Fortunately, ota-community-edition ignores that addendum i.e. keys generated by old fioctl work well. A problem is, however, that fioctl doesn't accept the initial Ed25519 key generated on the API.

This change fixes the problem by accepting both API-generated (RFC 8032 compliant) and old fioctl keys. It also goes further to store new Ed25519 keys in RFC 8032 format which is shorter (and well, standard).

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>