### PR TITLE
Fixup: correct order for actions in tuf rotate-all-keys for expired root

### DIFF
--- a/subcommands/keys/tuf_rotate_all_keys.go
+++ b/subcommands/keys/tuf_rotate_all_keys.go
@@ -69,7 +69,7 @@ func doRotateAllKeys(cmd *cobra.Command, unusedArgs []string) {
 	tufUpdatesCmd.SetArgs(args)
 	subcommands.DieNotNil(tufUpdatesCmd.Execute())
 
-	args = []string{"rotate-online-key", "-r", "targets,snapshot,timestamp", "-y", keyType}
+	args = []string{"rotate-offline-key", "-r", "root", "-k", credsFile, "-y", keyType}
 	tufUpdatesCmd.SetArgs(args)
 	subcommands.DieNotNil(tufUpdatesCmd.Execute())
 
@@ -77,7 +77,11 @@ func doRotateAllKeys(cmd *cobra.Command, unusedArgs []string) {
 	tufUpdatesCmd.SetArgs(args)
 	subcommands.DieNotNil(tufUpdatesCmd.Execute())
 
-	args = []string{"rotate-offline-key", "-r", "root", "-sk", credsFile, "-y", keyType}
+	args = []string{"rotate-online-key", "-r", "targets,snapshot,timestamp", "-y", keyType}
+	tufUpdatesCmd.SetArgs(args)
+	subcommands.DieNotNil(tufUpdatesCmd.Execute())
+
+	args = []string{"sign", "-k", credsFile}
 	tufUpdatesCmd.SetArgs(args)
 	subcommands.DieNotNil(tufUpdatesCmd.Execute())
 


### PR DESCRIPTION
In case of expired root role the first action to take must be the TUF root key rotation. Otherwise, the API will complain about the too low expires field value.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>