### PR TITLE
Feature: make Ed25519 the default TUF keys type

### DIFF
--- a/subcommands/keys/tuf_rotate_all_keys.go
+++ b/subcommands/keys/tuf_rotate_all_keys.go
@@ -37,7 +37,7 @@ Migrate an old factory to use Ed25519 key type for all TUF signing keys (online 
 	rotate.Flags().StringP("targets-keys", "K", "", "Path to <offline-targets-creds.tgz> used to sign prod & wave TUF targets.")
 	_ = rotate.MarkFlagFilename("targets-keys")
 	rotate.Flags().BoolP("first-time", "", false, "Used for the first customer rotation. The command will download the initial root key.")
-	rotate.Flags().StringP("key-type", "y", tufKeyTypeNameRSA, "Key type, supported: Ed25519, RSA (default).")
+	rotate.Flags().StringP("key-type", "y", tufKeyTypeNameEd25519, "Key type, supported: Ed25519, RSA.")
 	rotate.Flags().StringP("changelog", "m", "", "Reason for doing rotation. Saved in root metadata for tracking change history.")
 	tufCmd.AddCommand(rotate)
 }

--- a/subcommands/keys/tuf_rotate_offline_key.go
+++ b/subcommands/keys/tuf_rotate_offline_key.go
@@ -48,7 +48,7 @@ When you rotate the TUF targets offline signing key:
 	rotate.Flags().StringP("targets-keys", "K", "", "Path to <offline-targets-creds.tgz> used to sign prod & wave TUF targets.")
 	_ = rotate.MarkFlagFilename("targets-keys")
 	rotate.Flags().BoolP("first-time", "", false, "Used for the first customer rotation. The command will download the initial root key.")
-	rotate.Flags().StringP("key-type", "y", tufKeyTypeNameRSA, "Key type, supported: Ed25519, RSA (default).")
+	rotate.Flags().StringP("key-type", "y", tufKeyTypeNameEd25519, "Key type, supported: Ed25519, RSA.")
 	rotate.Flags().StringP("changelog", "m", "", "Reason for doing rotation. Saved in root metadata for tracking change history.")
 	tufCmd.AddCommand(rotate)
 
@@ -67,7 +67,7 @@ Instead, please, use a new approach to rotate TUF root key:
 	}
 	legacyRotateRoot.Flags().BoolP("initial", "", false, "Used for the first customer rotation. The command will download the initial root key")
 	legacyRotateRoot.Flags().StringP("changelog", "m", "", "Reason for doing rotation. Saved in root metadata for tracking change history")
-	legacyRotateRoot.Flags().StringP("key-type", "y", tufKeyTypeNameRSA, "Key type, supported: Ed25519, RSA (default).")
+	legacyRotateRoot.Flags().StringP("key-type", "y", tufKeyTypeNameEd25519, "Key type, supported: Ed25519, RSA.")
 	cmd.AddCommand(legacyRotateRoot)
 
 	legacyRotateTargets := &cobra.Command{
@@ -87,7 +87,7 @@ Instead, please, use a new approach to rotate TUF targets key:
 		Annotations: map[string]string{tufCmdAnnotation: tufCmdRotateTargetsLegacy},
 		Args:        cobra.ExactArgs(1),
 	}
-	legacyRotateTargets.Flags().StringP("key-type", "y", tufKeyTypeNameRSA, "Key type, supported: Ed25519, RSA (default).")
+	legacyRotateTargets.Flags().StringP("key-type", "y", tufKeyTypeNameEd25519, "Key type, supported: Ed25519, RSA.")
 	legacyRotateTargets.Flags().StringP("changelog", "m", "", "Reason for doing rotation. Saved in root metadata for tracking change history.")
 	cmd.AddCommand(legacyRotateTargets)
 }

--- a/subcommands/keys/tuf_updates_rotate_offline_key.go
+++ b/subcommands/keys/tuf_updates_rotate_offline_key.go
@@ -49,7 +49,7 @@ When you rotate the TUF targets offline signing key:
 	_ = rotate.MarkFlagFilename("keys")
 	rotate.Flags().StringP("targets-keys", "K", "", "Path to <tuf-targets-keys.tgz> used to sign prod & wave TUF targets.")
 	_ = rotate.MarkFlagFilename("targets-keys")
-	rotate.Flags().StringP("key-type", "y", tufKeyTypeNameRSA, "Key type, supported: Ed25519, RSA (default).")
+	rotate.Flags().StringP("key-type", "y", tufKeyTypeNameEd25519, "Key type, supported: Ed25519, RSA.")
 	rotate.Flags().BoolP("sign", "s", false, "Sign the new TUF root using the offline root keys.")
 	tufUpdatesCmd.AddCommand(rotate)
 }

--- a/subcommands/keys/tuf_updates_rotate_online_key.go
+++ b/subcommands/keys/tuf_updates_rotate_online_key.go
@@ -41,7 +41,7 @@ When you apply the online key rotation, these features are temporarily disabled 
 	rotate.Flags().StringP("txid", "x", "", "TUF root updates transaction ID.")
 	rotate.Flags().StringP("keys", "k", "", "Path to <tuf-root-keys.tgz> used to sign TUF root.")
 	_ = rotate.MarkFlagFilename("keys")
-	rotate.Flags().StringP("key-type", "y", tufKeyTypeNameRSA, "Key type, supported: Ed25519, RSA (default).")
+	rotate.Flags().StringP("key-type", "y", tufKeyTypeNameEd25519, "Key type, supported: Ed25519, RSA.")
 	rotate.Flags().BoolP("sign", "s", false, "Sign the new TUF root using the offline root keys.")
 	rotate.MarkFlagsRequiredTogether("sign", "keys")
 	tufUpdatesCmd.AddCommand(rotate)


### PR DESCRIPTION
Note: the new cobra we use add (default ED25519) to the help message. So, I dropped the word "(default)" from the message itself.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>