### PR TITLE
subcommands/keys/tuf: correct help message

### DIFF
--- a/subcommands/keys/tuf_updates.go
+++ b/subcommands/keys/tuf_updates.go
@@ -54,7 +54,7 @@ func init() {
 				fmt.Println(`
 No changes were made to your Factory.
 Please, cancel the staged TUF root updates
-using the "fioctl keys updates cancel" command, and try again later.`)
+using the "fioctl keys tuf updates cancel" command, and try again later.`)
 			} else {
 				// The init phase failed itself, so there is no active transaction.
 				fmt.Println(`

--- a/subcommands/keys/tuf_updates_apply.go
+++ b/subcommands/keys/tuf_updates_apply.go
@@ -48,7 +48,7 @@ func doTufUpdatesApply(cmd *cobra.Command, args []string) {
 			msg += `No changes were made to your Factory.
 There are two options available for you now:
 - fix the errors listed above and run the "fioctl keys tuf updates apply" again.
-- cancel the staged TUF root updates using the "fioctl keys updates cancel"`
+- cancel the staged TUF root updates using the "fioctl keys tuf updates cancel"`
 		} else {
 			msg += `
 This is a critical error: Staged TUF root updates may be partially applied to your Factory.


### PR DESCRIPTION
Fix the help message for fioctl keys cancel which should now be fioctl keys tuf cancel. 

Signed-off-by: Tyler Baker <tyler@foundries.io>