### PR TITLE
fix(docker): Safeguard config.json not being found

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -104,7 +106,7 @@ func getConfigDir() string {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	if _, err := os.Stat(config); os.IsNotExist(err) {
+	if _, err := os.Stat(config); errors.Is(err, fs.ErrNotExist) {
 		if err := os.Mkdir(config, 0755); err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/subcommands/common.go
+++ b/subcommands/common.go
@@ -233,7 +233,7 @@ func FindWritableDirInPath(helperPath string) string {
 	// Give preference to helper executable location if its in PATH
 	if len(helperPath) > 0 {
 		if _, ok := paths[helperPath]; ok {
-			if isWritable(helperPath) {
+			if IsWritable(helperPath) {
 				return helperPath
 			}
 		}
@@ -241,7 +241,7 @@ func FindWritableDirInPath(helperPath string) string {
 
 	// Now try everything
 	for _, path := range filepath.SplitList(path) {
-		if isWritable(path) {
+		if IsWritable(path) {
 			return path
 		}
 	}

--- a/subcommands/common_unix.go
+++ b/subcommands/common_unix.go
@@ -5,6 +5,6 @@ package subcommands
 
 import "golang.org/x/sys/unix"
 
-func isWritable(dir string) bool {
+func IsWritable(dir string) bool {
 	return unix.Access(dir, unix.W_OK) == nil
 }

--- a/subcommands/common_windows.go
+++ b/subcommands/common_windows.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 )
 
-func isWritable(dir string) bool {
+func IsWritable(dir string) bool {
 	if hwnd, err := syscall.CreateFile(syscall.StringToUTF16Ptr(dir), 2, 0, nil, syscall.OPEN_EXISTING, syscall.FILE_FLAG_BACKUP_SEMANTICS|syscall.FILE_FLAG_OPEN_REPARSE_POINT, 0); err == nil {
 		_ = syscall.CloseHandle(hwnd)
 		return true

--- a/subcommands/docker/cmd.go
+++ b/subcommands/docker/cmd.go
@@ -29,6 +29,9 @@ func NewCommand() *cobra.Command {
 	}
 	helperPath = subcommands.FindWritableDirInPath(helperPath)
 	dockerConfigFile = dockerConfigPath()
+	if !subcommands.IsWritable(dockerConfigFile) {
+		dockerConfigFile = ""
+	}
 
 	cmd := &cobra.Command{
 		Use:   "configure-docker",

--- a/subcommands/docker/cmd.go
+++ b/subcommands/docker/cmd.go
@@ -91,7 +91,7 @@ func doDockerCreds(cmd *cobra.Command, args []string) {
 	bytes, err := os.ReadFile(dockerConfigFile)
 	if os.IsNotExist(err) {
 		dockerConfig := filepath.Dir(dockerConfigFile)
-		if _, err := os.Stat(filepath.Dir(dockerConfig)); os.IsNotExist(err) {
+		if _, err := os.Stat(dockerConfig); os.IsNotExist(err) {
 			fmt.Println("Creating docker config directory:", dockerConfig)
 			subcommands.DieNotNil(os.Mkdir(dockerConfig, 0o755))
 		}

--- a/subcommands/docker/cmd.go
+++ b/subcommands/docker/cmd.go
@@ -2,7 +2,9 @@ package docker
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"os/user"
@@ -89,9 +91,9 @@ func doDockerCreds(cmd *cobra.Command, args []string) {
 
 	var config map[string]interface{}
 	bytes, err := os.ReadFile(dockerConfigFile)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		dockerConfig := filepath.Dir(dockerConfigFile)
-		if _, err := os.Stat(dockerConfig); os.IsNotExist(err) {
+		if _, err := os.Stat(dockerConfig); errors.Is(err, fs.ErrNotExist) {
 			fmt.Println("Creating docker config directory:", dockerConfig)
 			subcommands.DieNotNil(os.Mkdir(dockerConfig, 0o755))
 		}

--- a/subcommands/keys/tuf_updates_rotate_offline_key.go
+++ b/subcommands/keys/tuf_updates_rotate_offline_key.go
@@ -3,6 +3,7 @@ package keys
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"time"
 
@@ -145,7 +146,7 @@ func doTufUpdatesRotateOfflineTargetsKey(cmd *cobra.Command) {
 		targetsCreds, err = GetOfflineCreds(targetsKeysFile)
 		subcommands.DieNotNil(err)
 		subcommands.AssertWritable(targetsKeysFile)
-	} else if os.IsNotExist(err) {
+	} else if errors.Is(err, fs.ErrNotExist) {
 		targetsCreds = make(OfflineCreds, 0)
 		saveTufCreds(targetsKeysFile, targetsCreds)
 	} else {


### PR DESCRIPTION
This PR just adds a way to safeguard against the potential situation that someone just installs docker but never runs it yet. In that case there is no `.docker` dir created and no `config.json`.

In addition the reason the error checking is changed is because of an [internal comment of golang itself](https://pkg.go.dev/os#IsNotExist).