### PR TITLE
refactor(errors): Refactoring file not exist error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -104,7 +106,7 @@ func getConfigDir() string {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	if _, err := os.Stat(config); os.IsNotExist(err) {
+	if _, err := os.Stat(config); errors.Is(err, fs.ErrNotExist) {
 		if err := os.Mkdir(config, 0755); err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/subcommands/keys/tuf_updates_rotate_offline_key.go
+++ b/subcommands/keys/tuf_updates_rotate_offline_key.go
@@ -3,6 +3,7 @@ package keys
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"time"
 
@@ -145,7 +146,7 @@ func doTufUpdatesRotateOfflineTargetsKey(cmd *cobra.Command) {
 		targetsCreds, err = GetOfflineCreds(targetsKeysFile)
 		subcommands.DieNotNil(err)
 		subcommands.AssertWritable(targetsKeysFile)
-	} else if os.IsNotExist(err) {
+	} else if errors.Is(err, fs.ErrNotExist) {
 		targetsCreds = make(OfflineCreds, 0)
 		saveTufCreds(targetsKeysFile, targetsCreds)
 	} else {


### PR DESCRIPTION
Making sure all error checking is done according to the new preferred way according to golang itself.