### PR TITLE
Bump golangci-ling to 1.51.2

### DIFF
--- a/.jobserv.yml
+++ b/.jobserv.yml
@@ -4,7 +4,7 @@ triggers:
     type: github_pr
     runs:
       - name: unit-test
-        container: golangci/golangci-lint:v1.49
+        container: golangci/golangci-lint:v1.51.2
         host-tag: amd64
         script: unit-test
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ format:
 	@gofmt -l  -w ./
 check:
 	@test -z $(shell gofmt -l ./ | tee /dev/stderr) || echo "[WARN] Fix formatting issues with 'make fmt'"
-	@test -x $(linter) || (echo "Please install linter from https://github.com/golangci/golangci-lint/releases/tag/v1.45.2 to $(HOME)/go/bin")
+	@test -x $(linter) || (echo "Please install linter from https://github.com/golangci/golangci-lint/releases/tag/v1.51.2 to $(HOME)/go/bin")
 	$(linter) run
 
 # Use the image for Dockerfile.build to build and install the tool.


### PR DESCRIPTION
I'm helping with LmP upgrade of Golang to 1.20 for fioconfig. So, my system-wide Golang version was upgraded to version 1.20. But, for some weird reason, older golangci-lint stopped working after that regardless of the go1.19 flag in go.mod.
It looks like it uses some of the Golang internals. The easiest solution is to upgrade golangci-lint to a newer version, which support Golang 1.17+.

Looking ahead, this is a good addition anyway to stay tuned.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>