### PR TITLE
cmd: Allow config file to come from environment

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,6 +116,10 @@ func getConfigDir() string {
 }
 
 func initConfig() {
+	cfgFileFromEnv := os.Getenv("FIOCTL_CONFIG")
+	if len(cfgFileFromEnv) > 0 {
+		cfgFile = cfgFileFromEnv
+	}
 	if cfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)


### PR DESCRIPTION
This allows you to set FIOCTL_CONFIG=/tmp/fioctl.yaml and then run normal fioctl commands from a shell. This is quite handy when working on multiple factories (without having to introduce a more complex config file format).