### PR TITLE
Adjust subcommands to execute correctly on Windows

### DIFF
--- a/subcommands/el2g/aws.go
+++ b/subcommands/el2g/aws.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 
 	"github.com/foundriesio/fioctl/subcommands"
 	"github.com/spf13/cobra"
@@ -62,6 +63,9 @@ func doAwsIOT(cmd *cobra.Command, args []string) {
 }
 
 func run(args ...string) map[string]string {
+	if runtime.GOOS == "windows" && args[0] == "/usr/bin/env" {
+		args = args[1:]
+	}
 	cmd := exec.Command(args[0], args[1:]...)
 	var out bytes.Buffer
 	cmd.Stdout = &out

--- a/x509/bash.go
+++ b/x509/bash.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package x509
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/foundriesio/fioctl/subcommands"
+)
+
+func run(name string, arg ...string) string {
+	cmd := exec.Command(name, arg...)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	subcommands.DieNotNil(err)
+	return string(out)
+}
+
+func CreateFactoryCa(ou string) string {
+	run("./" + CreateCaScript)
+	return string(readFile(FactoryCaCertFile))
+}
+
+func CreateDeviceCa(cn string, ou string) string {
+	run("./"+CreateDeviceCaScript, DeviceCaKeyFile, DeviceCaCertFile)
+	return string(readFile(DeviceCaCertFile))
+}
+
+func SignTlsCsr(csrPem string) string {
+	return run("./"+SignTlsScript, TlsCsrFile)
+}
+
+func SignCaCsr(csrPem string) string {
+	return run("./"+SignCaScript, OnlineCaCsrFile)
+}
+
+func SignEl2GoCsr(csrPem string) string {
+	tmpFile, err := os.CreateTemp("", "el2g-*.csr")
+	subcommands.DieNotNil(err)
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+	_, err = tmpFile.Write([]byte(csrPem))
+	subcommands.DieNotNil(err)
+	return run("./"+SignCaScript, tmpFile.Name())
+}

--- a/x509/common.go
+++ b/x509/common.go
@@ -1,0 +1,29 @@
+package x509
+
+import (
+	"os"
+
+	"github.com/foundriesio/fioctl/subcommands"
+)
+
+const (
+	FactoryCaKeyFile  string = "factory_ca.key"
+	FactoryCaCertFile string = "factory_ca.pem"
+	DeviceCaKeyFile   string = "local-ca.key"
+	DeviceCaCertFile  string = "local-ca.pem"
+	TlsCertFile       string = "tls-crt"
+	TlsCsrFile        string = "tls-csr"
+	OnlineCaCertFile  string = "online-crt"
+	OnlineCaCsrFile   string = "ca-csr"
+
+	CreateCaScript       string = "create_ca"
+	CreateDeviceCaScript string = "create_device_ca"
+	SignCaScript         string = "sign_ca_csr"
+	SignTlsScript        string = "sign_tls_csr"
+)
+
+func readFile(filename string) string {
+	data, err := os.ReadFile(filename)
+	subcommands.DieNotNil(err)
+	return string(data)
+}

--- a/x509/golang.go
+++ b/x509/golang.go
@@ -1,0 +1,196 @@
+//go:build windows
+
+package x509
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"time"
+
+	"github.com/foundriesio/fioctl/subcommands"
+)
+
+func writeFile(filename, contents string, mode os.FileMode) {
+	err := os.WriteFile(filename, []byte(contents), mode)
+	subcommands.DieNotNil(err)
+}
+
+func genRandomSerialNumber() *big.Int {
+	// Generate a 160 bits serial number (20 octets)
+	max := big.NewInt(0).Exp(big.NewInt(2), big.NewInt(160), nil)
+	serial, err := rand.Int(rand.Reader, max)
+	subcommands.DieNotNil(err)
+	return serial
+}
+
+func genAndSaveKey(fn string) *ecdsa.PrivateKey {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	subcommands.DieNotNil(err)
+
+	keyRaw, err := x509.MarshalECPrivateKey(priv)
+	subcommands.DieNotNil(err)
+
+	keyBlock := &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyRaw}
+
+	factoryKeyBytes := pem.EncodeToMemory(keyBlock)
+	err = os.WriteFile(fn, factoryKeyBytes, 0600)
+	subcommands.DieNotNil(err)
+	return priv
+}
+
+func genCertificate(crtTemplate *x509.Certificate, caCrt *x509.Certificate, pub any, signerKey *ecdsa.PrivateKey) string {
+	certRaw, err := x509.CreateCertificate(rand.Reader, crtTemplate, caCrt, pub, signerKey)
+	subcommands.DieNotNil(err)
+
+	certPemBlock := pem.Block{Type: "CERTIFICATE", Bytes: certRaw}
+	var certRow bytes.Buffer
+	err = pem.Encode(&certRow, &certPemBlock)
+	subcommands.DieNotNil(err)
+
+	return certRow.String()
+}
+
+func parsePemCertificateRequest(csrPem string) *x509.CertificateRequest {
+	pemBlock, _ := pem.Decode([]byte(csrPem))
+	clientCSR, err := x509.ParseCertificateRequest(pemBlock.Bytes)
+	subcommands.DieNotNil(err)
+	err = clientCSR.CheckSignature()
+	subcommands.DieNotNil(err)
+	return clientCSR
+}
+
+func parsePemPrivateKey(keyPem string) *ecdsa.PrivateKey {
+	caPrivateKeyPemBlock, _ := pem.Decode([]byte(keyPem))
+	caPrivateKey, err := x509.ParseECPrivateKey(caPrivateKeyPemBlock.Bytes)
+	subcommands.DieNotNil(err)
+	return caPrivateKey
+}
+
+func parsePemCertificate(crtPem string) *x509.Certificate {
+	caCrtPemBlock, _ := pem.Decode([]byte(crtPem))
+	crt, err := x509.ParseCertificate(caCrtPemBlock.Bytes)
+	subcommands.DieNotNil(err)
+	return crt
+}
+
+func marshalSubject(cn string, ou string) pkix.Name {
+	// In it's simpler form, this function would be replaced by
+	// pkix.Name{CommonName: cn, OrganizationalUnit: []string{ou}}
+	// However, x509 library uses PrintableString instead of UTF8String
+	// as ASN.1 field type. This function forces UTF8String instead, to
+	// avoid compatibility issues when using a device certificate created
+	// with libraries such as MbedTLS.
+	// x509 library also encodes OU and CN in a different order if compared
+	// to OpenSSL, which is less of an issue, but still worth to adjust
+	// while we are at it.
+	cnBytes, err := asn1.MarshalWithParams(cn, "utf8")
+	subcommands.DieNotNil(err)
+	ouBytes, err := asn1.MarshalWithParams(ou, "utf8")
+	subcommands.DieNotNil(err)
+	var (
+		oidCommonName         = []int{2, 5, 4, 3}
+		oidOrganizationalUnit = []int{2, 5, 4, 11}
+	)
+	pkixAttrTypeValue := []pkix.AttributeTypeAndValue{
+		{
+			Type:  oidCommonName,
+			Value: asn1.RawValue{FullBytes: cnBytes},
+		},
+		{
+			Type:  oidOrganizationalUnit,
+			Value: asn1.RawValue{FullBytes: ouBytes},
+		},
+	}
+	return pkix.Name{ExtraNames: pkixAttrTypeValue}
+}
+
+func CreateFactoryCa(ou string) string {
+	priv := genAndSaveKey(FactoryCaKeyFile)
+	crtTemplate := x509.Certificate{
+		SerialNumber: genRandomSerialNumber(),
+		Subject:      marshalSubject("Factory-CA", ou),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(20, 0, 0),
+
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	factoryCaString := genCertificate(&crtTemplate, &crtTemplate, &priv.PublicKey, priv)
+	writeFile(FactoryCaCertFile, factoryCaString, 0400)
+	return factoryCaString
+}
+
+func CreateDeviceCa(cn string, ou string) string {
+	factoryKey := parsePemPrivateKey(readFile(FactoryCaKeyFile))
+	factoryCa := parsePemCertificate(readFile(FactoryCaCertFile))
+	priv := genAndSaveKey(DeviceCaKeyFile)
+	crtTemplate := x509.Certificate{
+		SerialNumber: genRandomSerialNumber(),
+		Subject:      marshalSubject(cn, ou),
+		Issuer:       factoryCa.Subject,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	crtPem := genCertificate(&crtTemplate, factoryCa, &priv.PublicKey, factoryKey)
+	writeFile(DeviceCaCertFile, crtPem, 0400)
+	return crtPem
+}
+
+func SignTlsCsr(csrPem string) string {
+	csr := parsePemCertificateRequest(csrPem)
+	factoryKey := parsePemPrivateKey(readFile(FactoryCaKeyFile))
+	factoryCa := parsePemCertificate(readFile(FactoryCaCertFile))
+	crtTemplate := x509.Certificate{
+		SerialNumber: genRandomSerialNumber(),
+		Subject:      csr.Subject,
+		Issuer:       factoryCa.Subject,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+
+		IsCA:        true,
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:    csr.DNSNames,
+	}
+	crtPem := genCertificate(&crtTemplate, factoryCa, csr.PublicKey, factoryKey)
+	return crtPem
+}
+
+func SignCaCsr(csrPem string) string {
+	csr := parsePemCertificateRequest(csrPem)
+	factoryKey := parsePemPrivateKey(readFile(FactoryCaKeyFile))
+	factoryCa := parsePemCertificate(readFile(FactoryCaCertFile))
+	crtTemplate := x509.Certificate{
+		SerialNumber: genRandomSerialNumber(),
+		Subject:      csr.Subject,
+		Issuer:       factoryCa.Subject,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	crtPem := genCertificate(&crtTemplate, factoryCa, csr.PublicKey, factoryKey)
+	return crtPem
+}
+
+func SignEl2GoCsr(csrPem string) string {
+	return SignCaCsr(csrPem)
+}


### PR DESCRIPTION
Key changes are related to implementing keys and certificates generation in Go instead of using external script. I've tried to mimic the exact same output when using the original openssl commands. The x509 library, however, always considers the `X509v3 Key Usage` fields as critical, and `X509v3 Extended Key Usage` as not critical, leading to the following differences on the generated certificates:

**`tls-crt`, openssl:**
```
            X509v3 Extended Key Usage: critical
                TLS Web Server Authentication
```
**`tls-crt`, Go:**
```
            X509v3 Extended Key Usage: 
                TLS Web Server Authentication
```

and

**`factory_ca.pem`, openssl:**
```
            X509v3 Basic Constraints: 
                CA:TRUE
            X509v3 Key Usage: 
                Certificate Sign
            X509v3 Extended Key Usage: critical
                TLS Web Client Authentication, TLS Web Server Authentication
```
**`factory_ca.pem`, Go:**
```
            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Key Usage: critical
                Certificate Sign
            X509v3 Extended Key Usage: 
                TLS Web Server Authentication, TLS Web Client Authentication
```

It is possible to adjust the `critical` flag for each one of those fields, but it requires copying a bunch of code from the x509 library within fioctl, which I believe is not worth it.

I'm also not sure if there is a better way to get the CommonName for `local-ca.pem` (e.g., `fio-61263c864de34394ed8b66e4`). I'm currently looking for a `CN = ` line in the `create_device_ca` script


