### PR TITLE
Security: set buildmode to PIE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 COMMIT:=$(shell git describe HEAD)$(shell git diff --quiet || echo '+dirty')
 
-# Use linker flags to provide commit info
-LDFLAGS=-ldflags "-X=github.com/foundriesio/fioctl/subcommands/version.Commit=$(COMMIT)"
+# Use linker flags to provide commit info and create a PIE
+LDFLAGS=-buildmode=pie -ldflags "-X=github.com/foundriesio/fioctl/subcommands/version.Commit=$(COMMIT)"
 
 linter:=$(shell which golangci-lint 2>/dev/null || echo $(HOME)/go/bin/golangci-lint)
 


### PR DESCRIPTION
We tested the PIE (position independent executable) and RELRO (read-only relocation) linker flags for quite some time in our server-side Golang executables; they behaved quite well. So, now it is time to apply them to the Fioctl as well to harden its run-time security.

Platform-wise this change has the following effects:
- On Windows and Arm Darwin: no effect, everything is a PIE on these platforms. The `make build` creates _exactly the same binary_.
- On Amd64 Darwin: make a PIE executable. The binary size is slightly increase, giving a slightly better run-time protection.
- On Linux: make a PIE executable using RELRO. (see https://github.com/golang/go/blob/master/src/cmd/link/internal/ld/lib.go#L1551). The binary size is increase by 10%, giving a way better run-time protection.

A size increase from ~21MB to ~23MB for Linux is acceptable for the increased security.