### PR TITLE
Fix indentation error for gen-rst

### DIFF
--- a/subcommands/keys/tuf_updates_delete_offline_key.go
+++ b/subcommands/keys/tuf_updates_delete_offline_key.go
@@ -20,11 +20,13 @@ func init() {
 		Long: `Stage deletion of the offline TUF signing key for the Factory.
 
 There are two ways to delete the offline TUF signing key:
+
 - If you own the keys file - you can delete your key by providing your keys file.
   Fioctl will search through your keys file for an appropriate key to delete.
 - You can also provide an exact key ID to delete.
 
 When you delete the TUF targets offline signing key:
+
 - if there are production targets in your factory, corresponding signatures are also deleted.
   if any production targets lack enough signatures - you need to sign them using the "sign-prod-targets" command.
 - if there is an active wave in your factory, the TUF targets key deletion is not allowed.`,

--- a/subcommands/keys/tuf_updates_rotate_offline_key.go
+++ b/subcommands/keys/tuf_updates_rotate_offline_key.go
@@ -23,6 +23,7 @@ func init() {
 The new offline signing key will be used in both CI and production TUF root.
 
 When you rotate the TUF targets offline signing key:
+
 - If there are production targets in your factory, they are re-signed using the new key.
   This only applies to those production targets that were signed by a key you rotate.
 - If there is an active wave in your factory, the TUF targets rotation is not allowed.`,

--- a/subcommands/keys/tuf_updates_sign_prod_targets.go
+++ b/subcommands/keys/tuf_updates_sign_prod_targets.go
@@ -21,6 +21,7 @@ func init() {
 New signatures are staged for commit along with TUF root modifications.
 
 There are 3 use cases when this command comes handy:
+
 - You want to sign your Factory's production targets with a newly added offline TUF Targets key.
 - You increase the TUF targets signature threshold
   and need to sign your production targets with an additional key.


### PR DESCRIPTION
A newline was added before each list in command documentation across three commands. This should fix the issue where the output is used in sphinx and an indentation error causes a failure in the doc build.

Docs built without issue when changes were applied.

No related issue to link.