### PR TITLE
Revert "Security: set buildmode to PIE"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 COMMIT:=$(shell git describe HEAD)$(shell git diff --quiet || echo '+dirty')
 
-# Use linker flags to provide commit info and create a PIE
-LDFLAGS=-buildmode=pie -ldflags "-X=github.com/foundriesio/fioctl/subcommands/version.Commit=$(COMMIT)"
+# Use linker flags to provide commit info
+LDFLAGS=-ldflags "-X=github.com/foundriesio/fioctl/subcommands/version.Commit=$(COMMIT)"
 
 linter:=$(shell which golangci-lint 2>/dev/null || echo $(HOME)/go/bin/golangci-lint)
 


### PR DESCRIPTION
This reverts commit 6105efe04beb399ef1cba597337385af343ca458.

It was breaking the Alpine Linux we use to generate docs. There is something more in play around PIE than expected.