### PR TITLE
fix(actions): don't run action on forked repos

### DIFF
--- a/.github/workflows/tuf.yml
+++ b/.github/workflows/tuf.yml
@@ -4,10 +4,16 @@ on:
     # every 8 hours
     - cron: '0 */8 * * *'
   workflow_dispatch:
-    branches: [ main ]
+    inputs:
+      branches:
+        description: The branch to run on
+        required: false
+        default: 'main'
+        type: string
 
 jobs:
   resign:
+    if: github.repository == 'foundriesio/fioctl'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This small filter will make sure it will only run on the foundriesio/fioctl repo by default.