### PR TITLE
fix(git): Use absolute path instead

### DIFF
--- a/subcommands/git/cmd.go
+++ b/subcommands/git/cmd.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/foundriesio/fioctl/subcommands"
 	"github.com/sirupsen/logrus"
@@ -73,8 +74,10 @@ func doGitCreds(cmd *cobra.Command, args []string) {
 	helperName := "fio"
 	dst := filepath.Join(helperPath, GIT_CREDS_HELPER)
 	if runtime.GOOS == "windows" {
+		// To get around edge cases with git on Windows we use the absolute path
+		// So for example the following path will be used: C:/Program\\ Files/Git/bin/git-credential-fio.exe
 		dst += ".exe"
-		helperName += ".exe"
+		helperName = strings.ReplaceAll(filepath.ToSlash(dst), " ", "\\ ")
 	}
 
 	if len(sudoer) > 0 {


### PR DESCRIPTION
Installing `git` on Windows will most likely place it in the `Program Files` directory.

Following our own [docs](https://docs.foundries.io/latest/getting-started/install-fioctl/index.html#configuring-git) on Windows will run the command as Administrator and place the resulting credential helper in `C:\Program Files\Git\bin\`. In order to make it work as seamless as possible on Windows we use the [absolute path configuration](https://git-scm.com/docs/gitcredentials#_custom_helpers) for the credential helper in the `.gitconfig` file managing the global configuration for git. 

On Windows the absolute path has to be converted into a different format.

1. All `\` have to become `/`
2. All spaces have to be 'escaped' making a ` ` into `\\ `

This works around symlinks, permission errors and other edge cases on Windows. 
