### PR TITLE
client: Fix user API URL

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -1628,7 +1628,7 @@ func (a *Api) UsersList(factory string) ([]FactoryUser, error) {
 }
 
 func (a *Api) UserAccessDetails(factory string, user_id string) (*FactoryUserAccessDetails, error) {
-	url := a.serverUrl + "/ota/factories/" + factory + "/users/" + user_id
+	url := a.serverUrl + "/ota/factories/" + factory + "/users/" + user_id + "/"
 	body, err := a.Get(url)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The User API as defined by ota-lite wants a trailing slash. ota-lite sends a redirect back with the trailing slash. However, certainer certain reverse-proxies (GCP in our case) will try and resend the request but omit the auth header which results in our API getting an HTTP 401 response.