### PR TITLE
Enable Golang implementation of PKI globally

### DIFF
--- a/x509/bash.go
+++ b/x509/bash.go
@@ -1,4 +1,7 @@
-//go:build !windows
+//go:build bashpki || !go1.15
+
+// A reference implementation for those who want to customize their PKI.
+// This is turned off in vanilla Fioctl builds, and can be enabled in a fork.
 
 package x509
 

--- a/x509/golang.go
+++ b/x509/golang.go
@@ -1,4 +1,6 @@
-//go:build windows
+//go:build go1.15 && !bashpki
+
+// The crypto/ecdsa and crypto/elliptic were introduced in Golang 1.15.
 
 package x509
 


### PR DESCRIPTION
We have already tested this implementation on Windows in the field.
Also tested it on Linux using a local build.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>