### PR TITLE
WIP: Use XGo to enabled the CGo based builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 COMMIT?=$(shell git describe HEAD)$(shell git diff --quiet || echo '+dirty')
 
 # Use linker flags to provide commit info
-LDFLAGS=-ldflags "-X=github.com/foundriesio/fioctl/subcommands/version.Commit=$(COMMIT)"
+COMMON_LDFLAGS=-X=github.com/foundriesio/fioctl/subcommands/version.Commit=$(COMMIT)
+TARGET_LDFLAGS=
 
 linter:=$(shell which golangci-lint 2>/dev/null || echo $(HOME)/go/bin/golangci-lint)
 builder:=$(shell which xgo 2>/dev/null || echo $(HOME)/go/bin/xgo)
@@ -22,7 +23,8 @@ fioctl-%:
 	@test -x $(builder) || (echo "Please install xgo toolchain $(HOME)/go/bin: go install github.com/crazy-max/xgo@v0.30.0")
 	$(eval GOOS:=$(shell echo $* | cut -f1 -d\- ))
 	$(eval GOARCH:=$(shell echo $* | cut -f2- -d\-))
-	$(builder) --targets=$(GOOS)/$(GOARCH) -out bin/fioctl $(LDFLAGS) .
+	$(eval COMBINED_LDFLAGS=$(COMMON_LDFLAGS) $(TARGET_LDFLAGS))
+	$(builder) --targets=$(GOOS)/$(GOARCH) -out bin/fioctl --ldflags "$(COMBINED_LDFLAGS)" .
 	# This creates files as root, use `sudo chown --reference bin bin/fioctl-*` if you wish them under your user.
 
 format:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 COMMIT?=$(shell git describe HEAD)$(shell git diff --quiet || echo '+dirty')
 
 # Use linker flags to provide commit info
-COMMON_LDFLAGS=-X=github.com/foundriesio/fioctl/subcommands/version.Commit=$(COMMIT)
+VERSION_LDFLAGS=-X=github.com/foundriesio/fioctl/subcommands/version.Commit=$(COMMIT)
+COMMON_LDFLAGS=-v -linkmode=external $(VERSION_LDFLAGS)
 TARGET_LDFLAGS=
 
 linter:=$(shell which golangci-lint 2>/dev/null || echo $(HOME)/go/bin/golangci-lint)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ COMMIT?=$(shell git describe HEAD)$(shell git diff --quiet || echo '+dirty')
 
 # Use linker flags to provide commit info
 VERSION_LDFLAGS=-X=github.com/foundriesio/fioctl/subcommands/version.Commit=$(COMMIT)
-COMMON_LDFLAGS=-v -linkmode=external $(VERSION_LDFLAGS)
+COMMON_LDFLAGS=-v -s -w -linkmode=external $(VERSION_LDFLAGS)
 
 linter:=$(shell which golangci-lint 2>/dev/null || echo $(HOME)/go/bin/golangci-lint)
 builder:=$(shell which xgo 2>/dev/null || echo $(HOME)/go/bin/xgo)
@@ -24,7 +24,7 @@ fioctl-%:
 	$(eval GOOS:=$(shell echo $* | cut -f1 -d\- ))
 	$(eval GOARCH:=$(shell echo $* | cut -f2- -d\-))
 	$(eval TARGET_GOTAGS:=netgo,osusergo)
-	$(eval TARGET_LDFLAGS:=$(if $(shell test $(GOOS) = linux && echo "ok"),'-extldflags=-static',))
+	$(eval TARGET_LDFLAGS:=$(if $(shell test $(GOOS) = linux && echo "ok"),'-extldflags=-static -O1',))
 	$(eval TARGET_LDFLAGS:=$(if $(shell test $(GOOS) = windows && echo "ok"),'-extldflags=-static',$(TARGET_LDFLAGS)))
 	$(eval COMBINED_LDFLAGS=$(COMMON_LDFLAGS) $(TARGET_LDFLAGS))
 	$(builder) --targets=$(GOOS)/$(GOARCH) -out bin/fioctl --tags=$(TARGET_GOTAGS) --ldflags "$(COMBINED_LDFLAGS)" .

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ COMMIT?=$(shell git describe HEAD)$(shell git diff --quiet || echo '+dirty')
 # Use linker flags to provide commit info
 VERSION_LDFLAGS=-X=github.com/foundriesio/fioctl/subcommands/version.Commit=$(COMMIT)
 COMMON_LDFLAGS=-v -linkmode=external $(VERSION_LDFLAGS)
-TARGET_LDFLAGS=
 
 linter:=$(shell which golangci-lint 2>/dev/null || echo $(HOME)/go/bin/golangci-lint)
 builder:=$(shell which xgo 2>/dev/null || echo $(HOME)/go/bin/xgo)
@@ -24,8 +23,11 @@ fioctl-%:
 	@test -x $(builder) || (echo "Please install xgo toolchain $(HOME)/go/bin: go install github.com/crazy-max/xgo@v0.30.0")
 	$(eval GOOS:=$(shell echo $* | cut -f1 -d\- ))
 	$(eval GOARCH:=$(shell echo $* | cut -f2- -d\-))
+	$(eval TARGET_GOTAGS:=netgo,osusergo)
+	$(eval TARGET_LDFLAGS:=$(if $(shell test $(GOOS) = linux && echo "ok"),'-extldflags=-static',))
+	$(eval TARGET_LDFLAGS:=$(if $(shell test $(GOOS) = windows && echo "ok"),'-extldflags=-static',$(TARGET_LDFLAGS)))
 	$(eval COMBINED_LDFLAGS=$(COMMON_LDFLAGS) $(TARGET_LDFLAGS))
-	$(builder) --targets=$(GOOS)/$(GOARCH) -out bin/fioctl --ldflags "$(COMBINED_LDFLAGS)" .
+	$(builder) --targets=$(GOOS)/$(GOARCH) -out bin/fioctl --tags=$(TARGET_GOTAGS) --ldflags "$(COMBINED_LDFLAGS)" .
 	# This creates files as root, use `sudo chown --reference bin bin/fioctl-*` if you wish them under your user.
 
 format:


### PR DESCRIPTION
This should (expectedly) fail the GitHub build.
I will finish the CI part tomorrow.

But, this works well for me locally, so it should unblock @detsch on the HSM work.

It builds for all supported platforms, and much more.
I tested on Linux AMD64 (Ubuntu and Alpine), also may test on Windows.
I need a volunteer to test the binaries on Mac OS and Arm Linux.