### PR TITLE
[WIP] feat: add HSM support to Golang PKI code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/foundriesio/go-ecies v0.3.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/karrick/godiff v0.0.2
+	github.com/miekg/pkcs11 v1.1.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pelletier/go-toml v1.9.4
 	github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636
@@ -29,11 +30,13 @@ require (
 	cloud.google.com/go/compute v1.3.0 // indirect
 	cloud.google.com/go/iam v0.1.0 // indirect
 	cloud.google.com/go/kms v1.4.0 // indirect
+	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/google/go-p11-kit v0.4.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
@@ -41,6 +44,7 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
@@ -48,6 +52,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/thales-e-security/pool v0.0.2 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/net v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/logrus-bugsnag v0.0.0-20170309145241-6dbc35f2c30d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
+github.com/ThalesIgnite/crypto11 v1.2.5 h1:1IiIIEqYmBvUYFeMnHqRft4bwf/O36jryEUpY+9ef8E=
+github.com/ThalesIgnite/crypto11 v1.2.5/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR2E23+wTQe/MlE=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/beorn7/perks v0.0.0-20150223135152-b965b613227f/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bitly/go-hostpool v0.1.0/go.mod h1:4gOCgp6+NZnVqlKyZ/iBZFTAJKembaVENUpMkpg42fw=
@@ -175,6 +177,8 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-p11-kit v0.4.0 h1:2HCRptPun8gkfOJH6u8goMjCcGESuJpMx2ugozLtiL8=
+github.com/google/go-p11-kit v0.4.0/go.mod h1:tg3TK33e/pkQUoXAun7q1zD5VwmYcN20sPaMl4l3hJo=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -247,6 +251,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-sqlite3 v1.6.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
+github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v0.0.0-20150613213606-2caf8efc9366/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -262,6 +268,7 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -313,6 +320,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=
+github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
 github.com/theupdateframework/go-tuf v0.5.2 h1:habfDzTmpbzBLIFGWa2ZpVhYvFBoK0C1onC3a4zuPRA=
 github.com/theupdateframework/go-tuf v0.5.2/go.mod h1:SyMV5kg5n4uEclsyxXJZI2UxPFJNDc4Y+r7wv+MlvTA=
 github.com/theupdateframework/notary v0.7.0 h1:QyagRZ7wlSpjT5N2qQAh/pN+DVqgekv4DzbAiAiEL3c=

--- a/subcommands/el2g/gateway.go
+++ b/subcommands/el2g/gateway.go
@@ -46,7 +46,7 @@ func doDeviceGateway(cmd *cobra.Command, args []string) {
 	subcommands.DieNotNil(err)
 
 	fmt.Println("Signing CSR")
-	generatedCa := x509.SignEl2GoCsr(csr.Value)
+	generatedCa := x509.SignEl2GoCsr(&x509.KeyStorageFiles{}, csr.Value)
 
 	fmt.Println("Uploading signed certificate")
 	errPrefix := "Unable to upload certificate:\n" + generatedCa

--- a/x509/common.go
+++ b/x509/common.go
@@ -20,7 +20,16 @@ const (
 	CreateDeviceCaScript string = "create_device_ca"
 	SignCaScript         string = "sign_ca_csr"
 	SignTlsScript        string = "sign_tls_csr"
+
+	FactoryCaKeyPkcs11Id    string = "\x01"
+	FactoryCaKeyPkcs11Label string = "root-ca"
 )
+
+type HsmInfo struct {
+	Module     string
+	Pin        string
+	TokenLabel string
+}
 
 func readFile(filename string) string {
 	data, err := os.ReadFile(filename)

--- a/x509/golang_hsm.go
+++ b/x509/golang_hsm.go
@@ -1,0 +1,119 @@
+//go:build windows && dynamic && hsm
+
+package x509
+
+import (
+	"crypto"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/ThalesIgnite/crypto11"
+	"github.com/foundriesio/fioctl/subcommands"
+	"github.com/miekg/pkcs11"
+)
+
+type KeyStorageHsm struct {
+	Hsm HsmInfo
+}
+
+func (s *KeyStorageHsm) genAndSaveFactoryCaKey() (any, any) {
+	return s.genAndSaveKeyToHsm([]byte(FactoryCaKeyPkcs11Id), []byte(FactoryCaKeyPkcs11Label))
+}
+
+func (s *KeyStorageHsm) getFactoryCaKey() any {
+	return s.getKeyHsm([]byte(FactoryCaKeyPkcs11Id))
+}
+
+func (s *KeyStorageHsm) getKeyHsm(id []byte) crypto11.Signer {
+	cfg := crypto11.Config{
+		Path:        s.Hsm.Module,
+		TokenLabel:  s.Hsm.TokenLabel,
+		Pin:         s.Hsm.Pin,
+		MaxSessions: 0,
+	}
+
+	ctx, err := crypto11.Configure(&cfg)
+	subcommands.DieNotNil(err)
+
+	privKey, err := ctx.FindKeyPair(id, nil)
+	subcommands.DieNotNil(err)
+	if privKey == nil {
+		subcommands.DieNotNil(errors.New("Key with requested id not found"))
+	}
+
+	return privKey
+}
+func (s *KeyStorageHsm) genAndSaveKeyToHsm(id []byte, label []byte) (crypto11.Signer, crypto.PublicKey) {
+	// Need all deferred statements to commit before the getKeyHsm call below.
+	func() {
+		p := pkcs11.New(s.Hsm.Module)
+		err := p.Initialize()
+		subcommands.DieNotNil(err)
+
+		defer p.Destroy()
+		defer p.Finalize()
+
+		slots, err := p.GetSlotList(true)
+		subcommands.DieNotNil(err)
+
+		var matchedSlotId uint = math.MaxUint
+		for _, slotId := range slots {
+			token, err := p.GetTokenInfo(slotId)
+			if err != nil {
+				continue
+			}
+			if token.Label == s.Hsm.TokenLabel {
+				matchedSlotId = slotId
+				break
+			}
+		}
+
+		if matchedSlotId == math.MaxUint {
+			subcommands.DieNotNil(errors.New("PKCS#11: Unable to find Token" + s.Hsm.TokenLabel))
+		} else {
+			fmt.Printf("PKCS#11: Found Token %s at SlotID %d\n", s.Hsm.TokenLabel, matchedSlotId)
+		}
+
+		session, err := p.OpenSession(matchedSlotId, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
+		subcommands.DieNotNil(err)
+		defer p.CloseSession(session)
+
+		err = p.Login(session, pkcs11.CKU_USER, s.Hsm.Pin)
+		subcommands.DieNotNil(err)
+		defer p.Logout(session)
+
+		oidNamedCurveP256 := asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7}
+		marshaledOID, err := asn1.Marshal(oidNamedCurveP256)
+
+		publicKeyTemplate := []*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+			pkcs11.NewAttribute(pkcs11.CKA_LABEL, label),
+			pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_EC),
+			pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY),
+			pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, marshaledOID),
+			pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+			pkcs11.NewAttribute(pkcs11.CKA_VERIFY, true),
+			pkcs11.NewAttribute(pkcs11.CKA_DERIVE, true),
+		}
+		privateKeyTemplate := []*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+			pkcs11.NewAttribute(pkcs11.CKA_LABEL, label),
+			pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_EC),
+			pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PRIVATE_KEY),
+			pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+			pkcs11.NewAttribute(pkcs11.CKA_PRIVATE, true),
+			pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, false),
+			pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, true),
+			pkcs11.NewAttribute(pkcs11.CKA_SIGN, true),
+			pkcs11.NewAttribute(pkcs11.CKA_DERIVE, true),
+		}
+		_, _, err = p.GenerateKeyPair(session,
+			[]*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_EC_KEY_PAIR_GEN, nil)},
+			publicKeyTemplate, privateKeyTemplate)
+		subcommands.DieNotNil(err)
+	}()
+	priv := s.getKeyHsm(id)
+	return priv, priv.Public()
+}

--- a/x509/golang_no_hsm.go
+++ b/x509/golang_no_hsm.go
@@ -1,0 +1,27 @@
+//go:build windows && (!dynamic || !hsm)
+
+package x509
+
+import (
+	"errors"
+
+	"github.com/foundriesio/fioctl/subcommands"
+)
+
+type KeyStorageHsm struct {
+	Hsm HsmInfo
+}
+
+func (s *KeyStorageHsm) genAndSaveFactoryCaKey() (any, any) {
+	dieHsmUnsupported()
+	return nil, nil
+}
+
+func (s *KeyStorageHsm) getFactoryCaKey() any {
+	dieHsmUnsupported()
+	return nil
+}
+
+func dieHsmUnsupported() {
+	subcommands.DieNotNil(errors.New("This Fioctl binary was built without HSM support"))
+}


### PR DESCRIPTION
This commit adds to the Golang PKI code implementation the same HSM access features that were available in the original bash implementation.

----

I did some tests, including a complete `fioctl keys ca create` sequence using the new code + registration of a device with a key signed by the generated key. All seems fine. If the overall approach is OK, I'll do a few more detailed tests, to make sure it did not break something.

The code requires `CGO_ENABLED=1` but I did not commit any changes to the Makefile since @vkhoroz is working on the proper fix (PR #269)

I decided to keep the PR as simple as possible, avoiding to add characteristics that are not present on the original bash implementation. There are at least two things that I believe can be improved. Both seem to be easy to implement:
- Save local device CA private key to HSM as well;
- Allow `fioctl el2g config-device-gateway` to access the factory key from the HSM. That would require the `--hsm-*` options to be replicated in that sub-command
