### PR TITLE
(chore): Update go version from 1.19 to 1.21 and dockerfile

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,5 @@
 # Build using golang container
-FROM golang:1.19.0-alpine3.15
+FROM golang:1.21.0-alpine3.17
 
 RUN apk add --update --no-cache \
     git \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/foundriesio/fioctl
 
-go 1.19
+go 1.21
 
 require (
 	cloud.google.com/go/pubsub v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,7 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -230,6 +231,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -311,6 +313,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/theupdateframework/go-tuf v0.5.2 h1:habfDzTmpbzBLIFGWa2ZpVhYvFBoK0C1onC3a4zuPRA=
@@ -735,6 +738,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=


### PR DESCRIPTION
## Description

Update go version 

## Motivation 

Solve tech-debt 

## Tested locally
- Golang build and docker file build

```
 $ docker build -t fioctl-build -f Dockerfile.build .
[+] Building 32.2s (11/11) FINISHED                        docker:desktop-linux
 => [internal] load build definition from Dockerfile.build                 0.0s
 => => transferring dockerfile: 286B                                       0.0s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => [internal] load metadata for docker.io/library/golang:1.21.0-alpine3.  1.4s
 => [1/6] FROM docker.io/library/golang:1.21.0-alpine3.17@sha256:6467daf2  9.4s
 => => resolve docker.io/library/golang:1.21.0-alpine3.17@sha256:6467daf2  0.0s
 => => sha256:c93db5753d0c7e0b9c085935ddf1a54b1eb7fed49e5 6.18kB / 6.18kB  0.0s
 => => sha256:4060ece20d7ac783f52cbe28a35fd5b06f90f7b4d77 3.26MB / 3.26MB  0.5s
 => => sha256:adc7bbb5e99e84ba3fb2d95350e1269e7108ea7 286.37kB / 286.37kB  0.6s
 => => sha256:0eb1d125c0fbb027db413b8fd27d4e61831659067 63.99MB / 63.99MB  6.3s
 => => sha256:6467daf26aec6b82c750be4ca9b6aaf3a6a07ed22e1 1.65kB / 1.65kB  0.0s
 => => sha256:5bde5f87271115d9733fe5dc880e31bb06a2eef3f6c 1.16kB / 1.16kB  0.0s
 => => extracting sha256:4060ece20d7ac783f52cbe28a35fd5b06f90f7b4d773bae0  0.1s
 => => sha256:93714695fae3c6cad45f0f5df38c492033ce54d2a12c4f8 155B / 155B  1.0s
 => => extracting sha256:adc7bbb5e99e84ba3fb2d95350e1269e7108ea7e7ea4a8c4  0.0s
 => => extracting sha256:0eb1d125c0fbb027db413b8fd27d4e618316590679d4a3e7  2.9s
 => => extracting sha256:93714695fae3c6cad45f0f5df38c492033ce54d2a12c4f8a  0.0s
 => [internal] load build context                                          0.0s
 => => transferring context: 23.16kB                                       0.0s
 => [2/6] RUN apk add --update --no-cache     git     g++     make         7.6s
 => [3/6] RUN mkdir -p $HOME/fioctl                                        0.1s
 => [4/6] WORKDIR /fioctl                                                  0.0s 
 => [5/6] COPY . .                                                         0.1s
 => [6/6] RUN go mod download                                             12.4s
 => exporting to image                                                     1.1s
 => => exporting layers                                                    1.1s
 => => writing image sha256:c1ed9a3e936a89ca3676486e0fbbe7d6f1c954c90e4b5  0.0s
 => => naming to docker.io/library/fioctl-build                            0.0s
```