### PR TITLE
(chore): Add linter improvements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '~1.19'
+      - name: Clone the code
+        uses: actions/checkout@v4
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.51.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+run:
+  deadline: 5m
+  allow-parallel-runners: true

--- a/.jobserv.yml
+++ b/.jobserv.yml
@@ -1,13 +1,5 @@
 timeout: 30
 triggers:
-  - name: pull-request
-    type: github_pr
-    runs:
-      - name: unit-test
-        container: golangci/golangci-lint:v1.51.2
-        host-tag: amd64
-        script: unit-test
-
   - name: create-release
     type: git_poller
     params:


### PR DESCRIPTION
## Description
This PR improves our linting process by:
- Update Makefile to improve lint target and add the lint-fix which can fix small issues like format and to sort the imports
- Add linter check using github action, removing the need to check logs. Example:

![Screenshot 2023-09-23 at 15 45 45](https://github.com/foundriesio/fioctl/assets/7708031/b168fd00-235d-4931-8e6b-b4e2f28f267b)

##Motivation
- Make it easier to fix lint issues and do the review
- Move checks to GitHub actions
- Ensuring consistent linting behaviour
- **Remove the need to set up lint manually. See that when we run make lint if the bin does not exist the target will download it**, see;

```
$ make check                         
make lint
/Users/camilamacedo/go/src/github.com/foundriesio/fioctl/bin/golangci-lint run
```

- Allow leverage in the common checks to avoid errors; see proposed follow-up: