### PR TITLE
(chore) : add dependabot to keep project updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Description

Introduce Dependabot to ensure consistent and effortless updating of the project's dependencies.

GitHub's Dependabot will perform weekly checks and automatically create pull requests to update the Dockerfile, GitHub Actions, and go.mod dependencies. With a reliable Continuous Integration (CI) in place to validate the tool's functionality, this approach significantly streamlines the review process. This allows us to effortlessly keep our project updated, minimizing technical debt and promptly addressing any potential Common Vulnerabilities and Exposures (CVEs).