### PR TITLE
Add checks to validate bin builds

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,75 @@
+name: Binaries Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-binaries:
+    name: Build Binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~1.19'
+
+      - name: Build All Binaries
+        run: make
+
+      - name: Archive Binaries
+        uses: actions/upload-artifact@v2
+        with:
+          name: binaries
+          path: bin/
+
+  test:
+    needs: build-binaries
+    name: Check ${{ matrix.binary }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            binary: fioctl-linux-amd64
+          - os: ubuntu-latest
+            binary: fioctl-linux-arm64
+            qemu: true
+            qemu-platform: aarch64
+          - os: windows-latest
+            binary: fioctl-windows-amd64.exe
+          - os: macos-latest
+            binary: fioctl-darwin-amd64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Set up QEMU
+        if: matrix.qemu
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ matrix.qemu-platform }}
+
+      - name: Download Binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: binaries
+          path: bin/
+
+      - name: Set Execute Permission
+        if: runner.os != 'Windows'
+        run: chmod +x ./bin/${{ matrix.binary }}
+
+      - name: Install QEMU user static
+        if: matrix.qemu
+        run: sudo apt-get update && sudo apt-get install -y qemu-user-static
+        shell: bash
+
+      - name: Verify binary
+        run: |
+          if ("${{ matrix.qemu }}" -eq "true") {
+            qemu-${{ matrix.qemu-platform }}-static ./bin/${{ matrix.binary }} logout
+          } else {
+            ./bin/${{ matrix.binary }} logout
+          }
+        shell: pwsh

--- a/.jobserv.yml
+++ b/.jobserv.yml
@@ -24,25 +24,3 @@ scripts:
   unit-test: |
     #!/bin/sh -ex
     make check
-
-  create-binaries: |
-    #!/bin/sh -e
-    make
-
-    GH_REPO="https://api.github.com/repos/foundriesio/fioctl"
-    GH_TAGS="$GH_REPO/releases/tags/$tag"
-    AUTH="Authorization: token $(cat /secrets/githubtok)"
-
-    # Validate token.
-    curl -o /dev/null -sH "$AUTH" $GH_REPO || { echo "Error: Invalid repo, token or network issue!";  exit 1; }
-
-    response=$(curl -sH "$AUTH" $GH_TAGS)
-    eval $(echo "$response" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
-    [ "$id" ] || { echo "Error: Failed to get release id for tag: $tag"; echo "$response" | awk 'length($0)<100' >&2; exit 1; }
-
-    cd bin
-    for filename in `ls`; do
-      echo "Uploading $filename ..."
-      GH_ASSET="https://uploads.github.com/repos/foundriesio/fioctl/releases/$id/assets?name=$filename)"
-      curl --data-binary @"$filename" -H "$AUTH" -H "Content-Type: application/octet-stream" $GH_ASSET
-    done


### PR DESCRIPTION
## Automated Testing and Binary Building

### Description

- **Add GitHub action responsible for building and checking binaries for all platforms (less darwin/arm64) using the make targets.**
       - Darwin/arm64 is excluded from the build because it is not supported by GitHub's current infrastructure. 
       - For ARM architectures, this action utilizes QEMU to ensure that the generated ARM binaries are functional.
       

