### PR TITLE
chore: Improve Tool's Output for Better User Visibility and unify CLI output library

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -511,7 +511,7 @@ func (d Device) Online(inactiveHoursThreshold int) bool {
 			return false
 		}
 	} else {
-		logrus.Error(err)
+		color.Red(fmt.Sprint(err))
 		return false
 	}
 	return true
@@ -534,7 +534,7 @@ func NewApiClient(serverUrl string, config Config, caCertPath string, version st
 		}
 
 		if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
-			logrus.Warning("No certs appended, using system certs only")
+			color.Yellow("No certs appended, using system certs only")
 		}
 		tlsCfg.RootCAs = rootCAs
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/fatih/color"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -63,12 +64,13 @@ func Execute() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		color.Red(fmt.Sprint(err))
 		os.Exit(1)
 	}
 }
 
 func init() {
+	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.config/fioctl.yaml)")
@@ -103,12 +105,12 @@ func init() {
 func getConfigDir() string {
 	config, err := homedir.Expand("~/.config")
 	if err != nil {
-		fmt.Println(err)
+		color.Red(fmt.Sprint(err))
 		os.Exit(1)
 	}
 	if _, err := os.Stat(config); errors.Is(err, fs.ErrNotExist) {
 		if err := os.Mkdir(config, 0755); err != nil {
-			fmt.Println(err)
+			color.Red(fmt.Sprint(err))
 			os.Exit(1)
 		}
 	}
@@ -137,7 +139,7 @@ func initConfig() {
 			logrus.Debug("Config file not found")
 		} else {
 			// Config file was found but another error was produced
-			fmt.Println("ERROR: ", err)
+			color.Red("ERROR: ", err)
 			os.Exit(1)
 		}
 	}

--- a/subcommands/common.go
+++ b/subcommands/common.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"text/tabwriter"
 
+	"github.com/fatih/color"
+
 	"github.com/cheynewallace/tabby"
 	canonical "github.com/docker/go/canonical/json"
 	homedir "github.com/mitchellh/go-homedir"
@@ -138,7 +140,7 @@ func DieNotNil(err error, message ...string) {
 			parts = append(parts, p)
 		}
 		parts = append(parts, err)
-		fmt.Println(parts...)
+		color.Red(fmt.Sprint(parts...))
 		for _, w := range onLastWill {
 			w()
 		}
@@ -177,7 +179,7 @@ func AssertWritable(path string) {
 	DieNotNil(err)
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, st.Mode())
 	if err != nil {
-		fmt.Println("ERROR: File is not writeable:", path)
+		color.Red(fmt.Sprintf("ERROR: File is not writeable:%s", path))
 		os.Exit(1)
 	}
 	f.Close()

--- a/subcommands/config/wireguard.go
+++ b/subcommands/config/wireguard.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/fatih/color"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -59,7 +61,7 @@ func (w *WireguardServerConfig) Unmarshall(configVal string) {
 		} else if k == "enabled" {
 			w.Enabled = v != "0"
 		} else {
-			fmt.Println("ERROR: Unexpected client config key: ", k)
+			color.Red(fmt.Sprintf("ERROR: Unexpected client config key: %s", k))
 			os.Exit(1)
 		}
 	}

--- a/subcommands/devices/config_wireguard.go
+++ b/subcommands/devices/config_wireguard.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/fatih/color"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -54,7 +56,7 @@ func (w *WireguardClientConfig) Unmarshall(configVal string) {
 		} else if k == "pubkey" {
 			w.PublicKey = strings.TrimSpace(parts[1])
 		} else {
-			fmt.Println("ERROR: Unexpected client config key: ", k)
+			color.Red(fmt.Sprintf("ERROR: Unexpected client config key: %s ", k))
 			os.Exit(1)
 		}
 	}
@@ -94,7 +96,7 @@ func factoryIps(factory string) map[uint32]bool {
 	for _, item := range ipList {
 		ip, err := ipToUint32(item.Ip)
 		if err != nil {
-			logrus.Errorf("Unable to compute VPN Address for %s - %s", item.Name, item.Ip)
+			color.Red(fmt.Sprintf("Unable to compute VPN Address for %s - %s", item.Name, item.Ip))
 		} else {
 			ips[ip] = true
 		}
@@ -105,13 +107,13 @@ func factoryIps(factory string) map[uint32]bool {
 func findVpnAddress(factory string) string {
 	wsc := config.LoadWireguardServerConfig(factory, api)
 	if len(wsc.VpnAddress) == 0 || !wsc.Enabled {
-		fmt.Println("ERROR: A wireguard server has not been configured for this factory")
+		color.Red("ERROR: A wireguard server has not been configured for this factory")
 		os.Exit(1)
 	}
 	logrus.Debugf("VPN server address is: %s", wsc.VpnAddress)
 	serverIp, err := ipToUint32(wsc.VpnAddress)
 	if err != nil {
-		fmt.Println("ERROR: Wireguard server has an invalid IP Address: ", wsc.VpnAddress)
+		color.Red("ERROR: Wireguard server has an invalid IP Address: ", wsc.VpnAddress)
 		os.Exit(1)
 	}
 
@@ -123,7 +125,7 @@ func findVpnAddress(factory string) string {
 		}
 	}
 
-	fmt.Println("ERROR: Unable to find unique IP address for VPN")
+	color.Red("ERROR: Unable to find unique IP address for VPN")
 	os.Exit(1)
 	return ""
 }
@@ -144,7 +146,7 @@ func doConfigWireguard(cmd *cobra.Command, args []string) {
 		}
 		os.Exit(0)
 	} else if args[1] != "enable" && args[1] != "disable" {
-		fmt.Printf("Invalid argument: '%s'. Must be 'enable' or 'disable'\n", args[1])
+		color.Red(fmt.Sprintf("Invalid argument: '%s'. Must be 'enable' or 'disable'\n", args[1]))
 		os.Exit(0)
 	}
 
@@ -161,7 +163,7 @@ func doConfigWireguard(cmd *cobra.Command, args []string) {
 
 	if args[1] == "enable" {
 		if len(wcc.PublicKey) == 0 {
-			fmt.Println("ERROR: Device has no public key for VPN")
+			color.Red("ERROR: Device has no public key for VPN")
 			os.Exit(1)
 		}
 		wcc.Enabled = true

--- a/subcommands/devices/delete.go
+++ b/subcommands/devices/delete.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/fatih/color"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -25,7 +27,7 @@ func doDelete(cmd *cobra.Command, args []string) {
 	for _, name := range args {
 		fmt.Printf("Deleting %s .. ", name)
 		if err := api.DeviceDelete(factory, name); err != nil {
-			fmt.Printf("failed\n%s", err)
+			color.Red(fmt.Sprintf("failed\n%s", err))
 			os.Exit(1)
 		} else {
 			fmt.Printf("ok\n")

--- a/subcommands/devices/list.go
+++ b/subcommands/devices/list.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fatih/color"
+
 	"github.com/cheynewallace/tabby"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -54,7 +56,7 @@ func ownerFormatter(d *client.Device) string {
 	logrus.Debugf("Looking up user %s in factory %s", d.Owner, d.Factory)
 	users, err := api.UsersList(d.Factory)
 	if err != nil {
-		logrus.Errorf("Unable to look up users: %s", err)
+		color.Red(fmt.Sprintf("Unable to look up users: %s", err))
 		return "???"
 	}
 	id := "<not in factory: " + d.Factory + ">"
@@ -185,7 +187,7 @@ func showDeviceList(dl *client.DeviceList, showColumns []string) {
 	var cols = make([]interface{}, len(showColumns))
 	for idx, c := range showColumns {
 		if _, ok := Columns[c]; !ok {
-			fmt.Println("ERROR: Invalid column name:", c)
+			color.Red("ERROR: Invalid column name:", c)
 			os.Exit(1)
 		}
 		cols[idx] = strings.ToUpper(c)

--- a/subcommands/devices/rename.go
+++ b/subcommands/devices/rename.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/fatih/color"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -23,7 +25,7 @@ func doRename(cmd *cobra.Command, args []string) {
 	logrus.Debugf("Renaming %s -> %s", args[0], args[1])
 
 	if err := api.DeviceRename(factory, args[0], args[1]); err != nil {
-		fmt.Printf("failed\n%s", err)
+		color.Red(fmt.Sprintf("failed\n%s", err))
 		os.Exit(1)
 	}
 }

--- a/subcommands/docker/cmd.go
+++ b/subcommands/docker/cmd.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/fatih/color"
+
 	"github.com/foundriesio/fioctl/subcommands"
 	"github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
@@ -129,6 +131,7 @@ func RunCredsHelper() int {
 	if subcommands.Config.ClientCredentials.ClientSecret == "" {
 		msg := "ERROR: Your fioctl configuration does not appear to include oauth2 credentials. Please run `fioctl login` to configure and then try again.\n"
 		os.Stderr.WriteString(msg)
+		color.Red(msg)
 		os.Exit(1)
 	}
 	subcommands.Login(NewCommand()) // Ensure a fresh oauth2 access token

--- a/subcommands/git/cmd.go
+++ b/subcommands/git/cmd.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/fatih/color"
+
 	"github.com/foundriesio/fioctl/subcommands"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -112,6 +114,7 @@ func RunCredsHelper() int {
 	if subcommands.Config.ClientCredentials.ClientSecret == "" {
 		msg := "ERROR: Your fioctl configuration does not appear to include oauth2 credentials. Please run `fioctl login` to configure and then try again.\n"
 		os.Stderr.WriteString(msg)
+		color.Red(msg)
 		os.Exit(1)
 	}
 	subcommands.Login(NewCommand()) // Ensure a fresh oauth2 access tokenA

--- a/subcommands/keys/ca_create.go
+++ b/subcommands/keys/ca_create.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/fatih/color"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -65,7 +67,7 @@ This is optional.`,
 
 func writeFile(filename, contents string, mode os.FileMode) {
 	if err := os.WriteFile(filename, []byte(contents), mode); err != nil {
-		fmt.Printf("ERROR: Creating %s: %s", filename, err)
+		color.Red("ERROR: Creating %s: %s", filename, err)
 		os.Exit(1)
 	}
 }
@@ -84,7 +86,7 @@ func doCreateCA(cmd *cobra.Command, args []string) {
 
 	if len(hsmModule) > 0 {
 		if len(hsmPin) == 0 {
-			fmt.Println("ERROR: --hsm-pin is required with --hsm-module")
+			color.Red("ERROR: --hsm-pin is required with --hsm-module")
 			os.Exit(1)
 		}
 		os.Setenv("HSM_MODULE", hsmModule)

--- a/subcommands/login/cmd.go
+++ b/subcommands/login/cmd.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/fatih/color"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -69,7 +71,7 @@ func doLogin(cmd *cobra.Command, args []string) {
 	}
 
 	if creds.Config.ClientId == "" || creds.Config.ClientSecret == "" {
-		fmt.Println("Cannot execute login without client ID or client secret.")
+		color.Red("Cannot execute login without client ID or client secret.")
 		os.Exit(1)
 	}
 
@@ -106,7 +108,7 @@ func promptForCreds(credsUrl string) (string, string) {
 	clientSecret := strings.Trim(scanner.Text(), " ")
 
 	if clientId == "" || clientSecret == "" {
-		fmt.Println("Client ID and client credentials are both required.")
+		color.Red("ERROR: Client ID and client credentials are both required.")
 		os.Exit(1)
 	}
 

--- a/subcommands/secrets/list.go
+++ b/subcommands/secrets/list.go
@@ -1,8 +1,9 @@
 package secrets
 
 import (
-	"fmt"
 	"os"
+
+	"github.com/fatih/color"
 
 	"github.com/cheynewallace/tabby"
 	"github.com/sirupsen/logrus"
@@ -34,7 +35,7 @@ func doList(cmd *cobra.Command, args []string) {
 			t.AddLine(secret.Name)
 		}
 	} else if len(triggers) != 0 {
-		fmt.Println("ERROR: Factory configuration issue. Factory has unexpected number of triggers.")
+		color.Red("ERROR: Factory configuration issue. Factory has unexpected number of triggers.")
 		os.Exit(1)
 	}
 	t.Print()

--- a/subcommands/secrets/update.go
+++ b/subcommands/secrets/update.go
@@ -1,9 +1,10 @@
 package secrets
 
 import (
-	"fmt"
 	"os"
 	"strings"
+
+	"github.com/fatih/color"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -42,7 +43,7 @@ func doUpdate(cmd *cobra.Command, args []string) {
 	for i, arg := range args {
 		parts := strings.SplitN(arg, "=", 2)
 		if len(parts) != 2 {
-			fmt.Println("ERROR: Invalid key=value argument: ", arg)
+			color.Red("ERROR: Invalid key=value argument: ", arg)
 			os.Exit(1)
 		}
 		secrets[i].Name = parts[0]
@@ -67,7 +68,7 @@ func doUpdate(cmd *cobra.Command, args []string) {
 	} else if len(triggers) == 1 {
 		pt = triggers[0]
 	} else {
-		fmt.Println("ERROR: Factory configuration issue. Factory has unexpected number of triggers.")
+		color.Red("ERROR: Factory configuration issue. Factory has unexpected number of triggers.")
 		os.Exit(1)
 	}
 

--- a/subcommands/targets/artifacts.go
+++ b/subcommands/targets/artifacts.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -81,7 +83,7 @@ func (d *DlStatus) Write(p []byte) (int, error) {
 func downloadArtifact(factory string, target int, artifact string) {
 	firstSlash := strings.Index(artifact, "/")
 	if firstSlash < 1 {
-		fmt.Println("ERROR: Invalid artifact path:", artifact)
+		color.Red(fmt.Sprintf("ERROR: Invalid artifact path: %s", artifact))
 		os.Exit(1)
 	}
 	run := artifact[0:firstSlash]

--- a/subcommands/targets/edit.go
+++ b/subcommands/targets/edit.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/fatih/color"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -41,16 +43,16 @@ func doEdit(cmd *cobra.Command, args []string) {
 	// Create temp file to edit with
 	tmpfile, err := os.CreateTemp("", "targets.*.json")
 	if err != nil {
-		fmt.Println("Unable to create tempfile: ", err)
+		color.Red("Unable to create tempfile: ", err)
 		os.Exit(1)
 	}
 	defer os.Remove(tmpfile.Name())
 	if _, err := tmpfile.Write(orig); err != nil {
-		fmt.Println("Unable to write tempfile: ", err)
+		color.Red("Unable to write tempfile: ", err)
 		os.Exit(1)
 	}
 	if err := tmpfile.Close(); err != nil {
-		fmt.Println("Unable to close tempfile: ", err)
+		color.Red("Unable to close tempfile: ", err)
 		os.Exit(1)
 	}
 
@@ -72,7 +74,7 @@ func doEdit(cmd *cobra.Command, args []string) {
 	// Read it and see if its changed
 	content, err := os.ReadFile(tmpfile.Name())
 	if err != nil {
-		fmt.Println("ERROR: Unable to re-read tempfile:", err)
+		color.Red("ERROR: Unable to re-read tempfile:", err)
 	}
 	if bytes.Equal(content, orig) {
 		fmt.Println("No changes found, exiting.")
@@ -83,7 +85,7 @@ func doEdit(cmd *cobra.Command, args []string) {
 	var newTargets tuf.Files
 	err = json.Unmarshal(content, &newTargets)
 	if err != nil {
-		fmt.Println("Unable to parse new targets: ", err)
+		color.Red("Unable to parse new targets: ", err)
 		os.Exit(1)
 	}
 	type TargetsUp struct {
@@ -92,7 +94,7 @@ func doEdit(cmd *cobra.Command, args []string) {
 	upload := TargetsUp{newTargets}
 	content, err = json.Marshal(upload)
 	if err != nil {
-		fmt.Println("Unable to marshall targets data: ", err)
+		color.Red("Unable to marshall targets data: ", err)
 		os.Exit(1)
 	}
 

--- a/subcommands/targets/image.go
+++ b/subcommands/targets/image.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"regexp"
 
+	"github.com/fatih/color"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -41,8 +43,8 @@ func validateAppShortlist() {
 	pattern := `^[a-zA-Z0-9-_,]+$`
 	re := regexp.MustCompile(pattern)
 	if len(appsShortlist) > 0 && !re.MatchString(appsShortlist) {
-		fmt.Println("ERROR: Invalid value for apps:", appsShortlist)
-		fmt.Println("       apps must be ", pattern)
+		color.Red("ERROR: Invalid value for apps:", appsShortlist)
+		color.Red("       apps must be ", pattern)
 		os.Exit(1)
 	}
 }

--- a/subcommands/targets/list.go
+++ b/subcommands/targets/list.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fatih/color"
+
 	"github.com/cheynewallace/tabby"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -191,7 +193,7 @@ func doList(cmd *cobra.Command, args []string) {
 	var cols = make([]interface{}, len(showColumns))
 	for idx, c := range showColumns {
 		if _, ok := Columns[c]; !ok {
-			fmt.Println("ERROR: Invalid column name:", c)
+			color.Red("ERROR: Invalid column name:", c)
 			os.Exit(1)
 		}
 		cols[idx] = strings.ToUpper(c)

--- a/subcommands/targets/offline-update.go
+++ b/subcommands/targets/offline-update.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
+
 	"github.com/foundriesio/fioctl/client"
 	"github.com/foundriesio/fioctl/subcommands"
 	"github.com/spf13/cobra"
@@ -90,7 +92,7 @@ func doOfflineUpdate(cmd *cobra.Command, args []string) {
 			fmt.Printf("Downloading Apps fetched by the `assemble-system-image` run; build number:  %d, tag: %s...\n", ti.version, ti.buildTag)
 			err = downloadApps(factory, targetName, ti.version, ti.buildTag, path.Join(dstDir, "apps"))
 			if herr := client.AsHttpError(err); herr != nil && herr.Response.StatusCode == 404 {
-				fmt.Println("WARNING: The Target Apps were not fetched by the `assemble` run, make sure that App preloading is enabled if needed. The update won't include any Apps!")
+				color.Yellow("WARNING: The Target Apps were not fetched by the `assemble` run, make sure that App preloading is enabled if needed. The update won't include any Apps!")
 			} else {
 				subcommands.DieNotNil(err, "Failed to download Target's Apps:")
 			}

--- a/subcommands/targets/prune.go
+++ b/subcommands/targets/prune.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fatih/color"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -98,7 +100,7 @@ func doPrune(cmd *cobra.Command, args []string) {
 			for _, name := range target_names {
 				parts := strings.SplitN(name, "lmp-", 2)
 				if len(parts) != 2 {
-					fmt.Printf("Unable to decode target name: %s\n", name)
+					color.Red(fmt.Sprintf("Unable to decode target name: %s\n", name))
 					os.Exit(1)
 				}
 				custom, _ := api.TargetCustom(targets[name])
@@ -132,7 +134,7 @@ func doPrune(cmd *cobra.Command, args []string) {
 	} else {
 		for _, name := range args {
 			if _, ok := targets[name]; !ok {
-				fmt.Printf("Target(%s) not found in targets.json\n", name)
+				color.Red(fmt.Sprintf("Target(%s) not found in targets.json\n", name))
 				os.Exit(1)
 			}
 		}

--- a/subcommands/targets/show.go
+++ b/subcommands/targets/show.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fatih/color"
+
 	"github.com/cheynewallace/tabby"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -164,7 +166,7 @@ func doShowComposeApp(cmd *cobra.Command, args []string) {
 	for name, custom := range targets {
 		_, ok := custom.ComposeApps[appName]
 		if !ok {
-			fmt.Println("ERROR: App not found in target")
+			color.Red("ERROR: App not found in target")
 			os.Exit(1)
 		}
 		appInfo, err := api.TargetComposeApp(factory, name, appName)
@@ -172,12 +174,12 @@ func doShowComposeApp(cmd *cobra.Command, args []string) {
 
 		fmt.Println("Version:\n\t", appInfo.Uri)
 		if len(appInfo.Error) > 0 {
-			fmt.Println("Error:\n\t", appInfo.Error)
+			color.Red(fmt.Sprintf("Error:\n\t %s", appInfo.Error))
 		}
 		if appInfo.Warnings != nil {
-			fmt.Println("Warnings:")
+			color.Yellow("Warnings:")
 			for _, warn := range appInfo.Warnings {
-				fmt.Println("\t", warn)
+				color.Yellow("\t", warn)
 			}
 		}
 
@@ -265,7 +267,7 @@ func getTargets(factory string, prodTag string, version string) ([]string, map[s
 		names = append(names, name)
 	}
 	if len(matches) == 0 {
-		fmt.Println("ERROR: no target found for this version")
+		color.Red("ERROR: no target found for this version")
 		os.Exit(1)
 	}
 	sort.Strings(names)

--- a/subcommands/targets/tag.go
+++ b/subcommands/targets/tag.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/fatih/color"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -83,7 +85,7 @@ func doTag(cmd *cobra.Command, args []string) {
 			}
 		}
 		if len(updates) == 0 {
-			fmt.Println("ERROR: no targets found matching the given versions")
+			color.Red("ERROR: no targets found matching the given versions")
 			os.Exit(1)
 		}
 	} else {
@@ -100,7 +102,7 @@ func doTag(cmd *cobra.Command, args []string) {
 				}
 				fmt.Printf("Changing tags of %s from %s -> %s\n", name, custom.Tags, targetTags)
 			} else {
-				fmt.Printf("Target(%s) not found in targets.json\n", name)
+				color.Red(fmt.Sprintf("Target(%s) not found in targets.json\n", name))
 				os.Exit(1)
 			}
 		}

--- a/subcommands/version/cmd.go
+++ b/subcommands/version/cmd.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/fatih/color"
+
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -76,7 +78,7 @@ func DieNotNil(err error, message ...string) {
 			parts = append(parts, p)
 		}
 		parts = append(parts, err)
-		fmt.Println(parts...)
+		color.Red(fmt.Sprint(parts...))
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Description

Ensuring that users can swiftly identify critical warnings and errors is important for a smooth user experience. This PR focuses on making these critical messages stand out amidst the standard output of our tool. Specifically, the changes introduced are:
- Unify CLI Output Library: To provide a consistent output experience across all messages. (see that has places we are using fmt.Println others logrus which are not in debug mode and by last other, we are using the colour.faith )
- Color-coded Messages:
    - Errors are now highlighted in red, making them immediately noticeable.
    - Warnings are displayed in yellow, ensuring they are distinguishable from regular logs and errors.

Example:

![Screenshot 2023-10-02 at 13 28 55](https://github.com/foundriesio/fioctl/assets/7708031/a0fa583f-5c5f-4ae1-af94-4f0363dcb147)
