### PR TITLE
(feat): Warning users about create OSTree static deltas before rolling out waves

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -277,6 +277,10 @@ type ProjectTrigger struct {
 	Id      int             `json:"id,omitempty"`
 	Secrets []ProjectSecret `json:"secrets"`
 }
+type DeltaStats struct {
+	Sha256 string `json:"sha256"`
+	Size   int    `json:"size"`
+}
 
 type TufCustom struct {
 	HardwareIds    []string              `json:"hardwareIds,omitempty"`
@@ -286,6 +290,7 @@ type TufCustom struct {
 	ComposeApps    map[string]ComposeApp `json:"docker_compose_apps,omitempty"`
 	Name           string                `json:"name,omitempty"`
 	ContainersSha  string                `json:"containers-sha,omitempty"`
+	DeltaStats     *DeltaStats           `json:"delta-stats,omitempty"`
 	LmpManifestSha string                `json:"lmp-manifest-sha,omitempty"`
 	OverridesSha   string                `json:"meta-subscriber-overrides-sha,omitempty"`
 	Uri            string                `json:"uri,omitempty"`


### PR DESCRIPTION
Adds a warning message to inform users about the recommendation to use Static Deltas to optimize OTA downloads.
The message only appears when users create weaves that do not have static deltas.

## Local tests:

When no Static Deltas are in place: 

![Screenshot 2023-10-03 at 01 37 14](https://github.com/foundriesio/fioctl/assets/7708031/998a9cc5-8915-42ef-8378-b04f9d15d3ab)

