### PR TITLE
Feature: TLS certificate rotation for the factory PKI

### DIFF
--- a/client/foundries_pki.go
+++ b/client/foundries_pki.go
@@ -11,14 +11,17 @@ import (
 )
 
 type CaCerts struct {
-	RootCrt string `json:"root-crt"`
-	CaCrt   string `json:"ca-crt"`
-	CaCsr   string `json:"ca-csr"`
-	EstCrt  string `json:"est-tls-crt"`
-	TlsCrt  string `json:"tls-crt"`
-	TlsCsr  string `json:"tls-csr"`
+	RootCrt string `json:"root-crt,omitempty"`
+	CaCrt   string `json:"ca-crt,omitempty"`
+	EstCrt  string `json:"est-tls-crt,omitempty"`
+	TlsCrt  string `json:"tls-crt,omitempty"`
 
 	ChangeMeta ChangeMeta `json:"change-meta"`
+}
+
+type CaCsrs struct {
+	CaCsr  string `json:"ca-csr,omitempty"`
+	TlsCsr string `json:"tls-csr,omitempty"`
 }
 
 func (a *Api) FactoryGetCA(factory string) (CaCerts, error) {
@@ -35,10 +38,10 @@ func (a *Api) FactoryGetCA(factory string) (CaCerts, error) {
 	return resp, err
 }
 
-func (a *Api) FactoryCreateCA(factory string) (CaCerts, error) {
+func (a *Api) FactoryCreateCA(factory string) (CaCsrs, error) {
 	url := a.serverUrl + "/ota/factories/" + factory + "/certs/"
 	logrus.Debugf("Creating new factory CA %s", url)
-	var resp CaCerts
+	var resp CaCsrs
 
 	body, err := a.Post(url, []byte("{}"))
 	if err != nil {

--- a/client/foundries_pki.go
+++ b/client/foundries_pki.go
@@ -21,12 +21,14 @@ type CaCerts struct {
 
 type CaCsrs struct {
 	CaCsr  string `json:"ca-csr,omitempty"`
+	EstCsr string `json:"est-tls-csr,omitempty"`
 	TlsCsr string `json:"tls-csr,omitempty"`
 }
 
 type CaCreateOptions struct {
 	FirstTimeInit  bool `json:"first-time-init"`
 	CreateOnlineCa bool `json:"ca-csr"`
+	CreateEstCert  bool `json:"est-tls-csr"`
 	CreateTlsCert  bool `json:"tls-csr"`
 }
 
@@ -73,39 +75,6 @@ func (a *Api) FactoryPatchCA(factory string, certs CaCerts) error {
 	}
 
 	_, err = a.Patch(url, data)
-	return err
-}
-
-type estCsr struct {
-	TlsCsr string `json:"tls-csr"`
-}
-type estCrt struct {
-	TlsCrt string `json:"tls-crt"`
-}
-
-func (a *Api) FactoryCreateEstCsr(factory string) (string, error) {
-	url := a.serverUrl + "/ota/factories/" + factory + "/certs/est/"
-	logrus.Debugf("Creating EST CSR %s", url)
-	body, err := a.Post(url, nil)
-	if err != nil {
-		return "", err
-	}
-	var csr estCsr
-	if err = json.Unmarshal(*body, &csr); err != nil {
-		return "", err
-	}
-	return csr.TlsCsr, nil
-}
-
-func (a *Api) FactorySetEstCrt(factory string, cert string) error {
-	url := a.serverUrl + "/ota/factories/" + factory + "/certs/est/"
-	logrus.Debugf("Putting EST certs %s", url)
-	crt := estCrt{cert}
-	data, err := json.Marshal(crt)
-	if err != nil {
-		return err
-	}
-	_, err = a.Put(url, data)
 	return err
 }
 

--- a/client/foundries_pki.go
+++ b/client/foundries_pki.go
@@ -24,6 +24,12 @@ type CaCsrs struct {
 	TlsCsr string `json:"tls-csr,omitempty"`
 }
 
+type CaCreateOptions struct {
+	FirstTimeInit  bool `json:"first-time-init"`
+	CreateOnlineCa bool `json:"ca-csr"`
+	CreateTlsCert  bool `json:"tls-csr"`
+}
+
 func (a *Api) FactoryGetCA(factory string) (CaCerts, error) {
 	url := a.serverUrl + "/ota/factories/" + factory + "/certs/"
 	logrus.Debugf("Getting certs %s", url)
@@ -38,12 +44,17 @@ func (a *Api) FactoryGetCA(factory string) (CaCerts, error) {
 	return resp, err
 }
 
-func (a *Api) FactoryCreateCA(factory string) (CaCsrs, error) {
+func (a *Api) FactoryCreateCA(factory string, opts CaCreateOptions) (CaCsrs, error) {
 	url := a.serverUrl + "/ota/factories/" + factory + "/certs/"
 	logrus.Debugf("Creating new factory CA %s", url)
 	var resp CaCsrs
 
-	body, err := a.Post(url, []byte("{}"))
+	data, err := json.Marshal(opts)
+	if err != nil {
+		return resp, err
+	}
+
+	body, err := a.Post(url, data)
 	if err != nil {
 		return resp, err
 	}

--- a/subcommands/keys/ca_create.go
+++ b/subcommands/keys/ca_create.go
@@ -83,7 +83,7 @@ func doCreateCA(cmd *cobra.Command, args []string) {
 	logrus.Debugf("Create CA for %s under %s", factory, certsDir)
 	opts := client.CaCreateOptions{
 		FirstTimeInit:  true,
-		CreateOnlineCa: true,
+		CreateOnlineCa: createOnlineCA,
 		CreateTlsCert:  true,
 	}
 	csrs, err := api.FactoryCreateCA(factory, opts)

--- a/subcommands/keys/ca_create.go
+++ b/subcommands/keys/ca_create.go
@@ -81,7 +81,12 @@ func doCreateCA(cmd *cobra.Command, args []string) {
 	x509.InitHsm(hsm)
 
 	logrus.Debugf("Create CA for %s under %s", factory, certsDir)
-	csrs, err := api.FactoryCreateCA(factory)
+	opts := client.CaCreateOptions{
+		FirstTimeInit:  true,
+		CreateOnlineCa: true,
+		CreateTlsCert:  true,
+	}
+	csrs, err := api.FactoryCreateCA(factory, opts)
 	subcommands.DieNotNil(err)
 
 	var certs client.CaCerts

--- a/subcommands/keys/ca_rotate_tls.go
+++ b/subcommands/keys/ca_rotate_tls.go
@@ -1,0 +1,51 @@
+package keys
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/foundriesio/fioctl/client"
+	"github.com/foundriesio/fioctl/subcommands"
+	"github.com/foundriesio/fioctl/x509"
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "rotate-tls <PKI Directory>",
+		Short: "Rotate the TLS certificate used by Device Gateway and OSTree Server",
+		Run:   doRotateTls,
+		Args:  cobra.ExactArgs(1),
+	}
+	caCmd.AddCommand(cmd)
+	// HSM variables defined in ca_create.go
+	cmd.Flags().StringVarP(&hsmModule, "hsm-module", "", "", "Load a root CA key from a PKCS#11 compatible HSM using this module")
+	cmd.Flags().StringVarP(&hsmPin, "hsm-pin", "", "", "The PKCS#11 PIN to log into the HSM")
+	cmd.Flags().StringVarP(&hsmTokenLabel, "hsm-token-label", "", "", "The label of the HSM token containing the root CA key")
+}
+
+func doRotateTls(cmd *cobra.Command, args []string) {
+	factory := viper.GetString("factory")
+
+	subcommands.DieNotNil(os.Chdir(args[0]))
+	hsm, err := x509.ValidateHsmArgs(
+		hsmModule, hsmPin, hsmTokenLabel, "--hsm-module", "--hsm-pin", "--hsm-token-label")
+	subcommands.DieNotNil(err)
+	x509.InitHsm(hsm)
+
+	fmt.Println("Requesting new Foundries TLS CSR")
+	csrs, err := api.FactoryCreateCA(factory, client.CaCreateOptions{CreateTlsCert: true})
+	subcommands.DieNotNil(err)
+
+	if _, err := os.Stat(x509.TlsCertFile); !os.IsNotExist(err) {
+		fmt.Printf("Moving existing TLS cert file from %s to %s.bak", x509.TlsCertFile, x509.TlsCertFile)
+		subcommands.DieNotNil(os.Rename(x509.TlsCertFile, x509.TlsCertFile+".bak"))
+	}
+	fmt.Println("Signing Foundries TLS CSR")
+	certs := client.CaCerts{TlsCrt: x509.SignTlsCsr(csrs.TlsCsr)}
+
+	fmt.Println("Uploading signed certs to Foundries")
+	subcommands.DieNotNil(api.FactoryPatchCA(factory, certs))
+}

--- a/subcommands/keys/est.go
+++ b/subcommands/keys/est.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/foundriesio/fioctl/client"
 	"github.com/foundriesio/fioctl/subcommands"
 	"github.com/foundriesio/fioctl/x509"
 	"github.com/sirupsen/logrus"
@@ -63,11 +64,11 @@ func doAuthorizeEst(cmd *cobra.Command, args []string) {
 	x509.InitHsm(hsm)
 
 	logrus.Debugf("Authorizing EST for %s", factory)
-	csr, err := api.FactoryCreateEstCsr(factory)
+	csrs, err := api.FactoryCreateCA(factory, client.CaCreateOptions{CreateEstCert: true})
 	subcommands.DieNotNil(err)
 
-	cert := x509.SignEstCsr(csr)
+	certs := client.CaCerts{EstCrt: x509.SignEstCsr(csrs.EstCsr)}
 	fmt.Println("Uploading new EST certificate:")
-	fmt.Println(cert)
-	subcommands.DieNotNil(api.FactorySetEstCrt(factory, cert))
+	fmt.Println(certs.EstCrt)
+	subcommands.DieNotNil(api.FactoryPatchCA(factory, certs))
 }


### PR DESCRIPTION
Supported operations:

- Rotate EST certificate (only cleanup, tested happy-path, TBD end-2-end).
- Rotate TLS certificate (new feature, tested end-2-end).

Device CA rotations will be a separate PR, as they are more complex.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>