### PR TITLE
Tooling: enable gofmt -s option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ linter: has-linter
 	$(linter) run --fix ${EXTRA_LINTER_FLAGS}
 
 format-check:
-	@test -z $(shell gofmt -l ./ | tee /dev/stderr) || echo "[WARN] Fix formatting issues with 'make format-check'"
+	@test -z $(shell gofmt -l -s ./ | tee /dev/stderr) || echo "[WARN] Fix formatting issues with 'make format-check'"
 
 format:
-	@gofmt -l  -w ./
+	@gofmt -l -s -w ./
 
 check: format-check linter-check
 	@true


### PR DESCRIPTION
It simplifies code where relevant.

I've hit it several times already that one of linters complains about formatting of auto-formatted code. This option helps removing the routine of fixing such warnings.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>