### PR TITLE
Feature: allow to revoke or disable device CA

### DIFF
--- a/client/foundries_pki.go
+++ b/client/foundries_pki.go
@@ -16,6 +16,8 @@ type CaCerts struct {
 	EstCrt  string `json:"est-tls-crt,omitempty"`
 	TlsCrt  string `json:"tls-crt,omitempty"`
 
+	CaRevokeCrl string `json:"ca-revoke-crl,omitempty"`
+
 	ChangeMeta ChangeMeta `json:"change-meta"`
 }
 

--- a/client/foundries_pki.go
+++ b/client/foundries_pki.go
@@ -16,7 +16,8 @@ type CaCerts struct {
 	EstCrt  string `json:"est-tls-crt,omitempty"`
 	TlsCrt  string `json:"tls-crt,omitempty"`
 
-	CaRevokeCrl string `json:"ca-revoke-crl,omitempty"`
+	CaRevokeCrl string   `json:"ca-revoke-crl,omitempty"`
+	CaDisabled  []string `json:"disabled-ca-serials,omitempty"` // readonly
 
 	ChangeMeta ChangeMeta `json:"change-meta"`
 }

--- a/subcommands/keys/ca_revoke_device_ca.go
+++ b/subcommands/keys/ca_revoke_device_ca.go
@@ -14,8 +14,14 @@ import (
 	"github.com/foundriesio/fioctl/x509"
 )
 
+const (
+	crlCmdAnnotation      = "crl-revoke"
+	crlCmdRevokeDeviceCa  = "revoke-device-ca"
+	crlCmdDisableDeviceCa = "disable-device-ca"
+)
+
 func init() {
-	cmd := &cobra.Command{
+	revokeCmd := &cobra.Command{
 		Use:   "revoke-device-ca <PKI Directory>",
 		Short: "Revoke device CA, so that devices with client certificates it issued can no longer connect to your Factory",
 		Run:   doRevokeDeviceCa,
@@ -44,16 +50,51 @@ fioctl keys ca revoke-device-ca /path/to/pki/dir --ca-file local-ca \
 
 # Show a generated CRL that would be sent to the server to revoke a local device CA, without actually revoking it.
 fioctl keys ca revoke-device-ca /path/to/pki/dir --ca-file local-ca --dry-run --pretty`,
+		Annotations: map[string]string{crlCmdAnnotation: crlCmdRevokeDeviceCa},
 	}
-	caCmd.AddCommand(cmd)
+	caCmd.AddCommand(revokeCmd)
+	addRevokeCmdFlags(revokeCmd, "revoke")
+
+	disableCmd := &cobra.Command{
+		Use:   "disable-device-ca <PKI Directory>",
+		Short: "Disable device CA, so that new devices with client certificates it issued can no longer be registered",
+		Run:   doRevokeDeviceCa,
+		Args:  cobra.ExactArgs(1),
+		Long: `Disable device CA, so that new devices with client certificates it issued can no longer be registered.
+
+When the online or local device CA is disabled:
+- It is no longer possible to register new devices with client certificates it had issued.
+- Existing devices with client certificates it issued may continue to connect and use your Factory.
+
+Usually, when the device CA is compromised, a user should:
+1. Immediately disable a given device CA using "fioctl keys ca disable-device-ca <PKI Directory> --serial <CA Serial>".
+2. Inspect their devices with client certificates issued by that device CA, and remove compromised devices (see "fioctl devices list|delete").
+3. Create a new device CA using "fioctl keys ca add-device-ca <PKI Directory> --online-ca|--local-ca".
+4. Rotate a client certificate of legitimate devices to the certificate issued by a new device CA (see "fioctl devices config rotate-certs").
+5. Revoke a given device CA using "fioctl keys ca revoke-device-ca <PKI Directory> --serial <CA Serial>".`,
+		Example: `
+# Disable two device CAs given their serial numbers:
+fioctl keys ca disable-device-ca /path/to/pki/dir --ca-serial <base-10-serial-1> --ca-file <base-10-serial-2>
+
+# Show a generated CRL that would be sent to the server to disable a local device CA, without actually disabling it.
+fioctl keys ca disable-device-ca /path/to/pki/dir --ca-file local-ca --dry-run --pretty
+
+# See "fioctl keys ca revoke-device-ca --help" for more examples; these two commands have a very similar syntax.`,
+		Annotations: map[string]string{crlCmdAnnotation: crlCmdDisableDeviceCa},
+	}
+	caCmd.AddCommand(disableCmd)
+	addRevokeCmdFlags(disableCmd, "disable")
+}
+
+func addRevokeCmdFlags(cmd *cobra.Command, op string) {
 	cmd.Flags().BoolP("dry-run", "", false,
-		"Do not revoke the certificate, but instead show a generated CRL that will be uploaded to the server.")
+		"Do not "+op+" the certificate, but instead show a generated CRL that will be uploaded to the server.")
 	cmd.Flags().BoolP("pretty", "", false,
 		"Can be used with dry-run to show the generated CRL in a pretty format.")
 	cmd.Flags().StringArrayP("ca-file", "", nil,
-		"A file name of the device CA to revoke. Can be used multiple times to revoke several device CAs.")
+		"A file name of the device CA to "+op+". Can be used multiple times to "+op+" several device CAs")
 	cmd.Flags().StringArrayP("ca-serial", "", nil,
-		"A serial number (base 10) of the device CA to revoke. Can be used multiple times to revoke several device CAs.")
+		"A serial number (base 10) of the device CA to "+op+". Can be used multiple times to "+op+" several device CAs")
 	_ = cmd.MarkFlagFilename("ca-file")
 	// HSM variables defined in ca_create.go
 	cmd.Flags().StringVarP(&hsmModule, "hsm-module", "", "", "Load a root CA key from a PKCS#11 compatible HSM using this module")
@@ -68,6 +109,10 @@ func doRevokeDeviceCa(cmd *cobra.Command, args []string) {
 	// pretty, _ := cmd.Flags().GetBool("pretty")
 	caFiles, _ := cmd.Flags().GetStringArray("ca-file")
 	caSerials, _ := cmd.Flags().GetStringArray("ca-serial")
+	crlReason := map[string]int{
+		crlCmdRevokeDeviceCa:  x509.CrlCaRevoke,
+		crlCmdDisableDeviceCa: x509.CrlCaDisable,
+	}[cmd.Annotations[crlCmdAnnotation]]
 
 	if len(caFiles)+len(caSerials) == 0 {
 		subcommands.DieNotNil(errors.New("At least one of --ca-file or --ca-serial must be provided"))
@@ -86,11 +131,11 @@ func doRevokeDeviceCa(cmd *cobra.Command, args []string) {
 		if _, ok := num.SetString(serial, 10); !ok {
 			subcommands.DieNotNil(fmt.Errorf("Value %s is not a valid base 10 serial", serial))
 		}
-		toRevoke[serial] = x509.CrlCaRevoke
+		toRevoke[serial] = crlReason
 	}
 	for _, filename := range caFiles {
 		ca := x509.LoadCertFromFile(filename)
-		toRevoke[ca.SerialNumber.Text(10)] = x509.CrlCaRevoke
+		toRevoke[ca.SerialNumber.Text(10)] = crlReason
 	}
 	fmt.Println("Signing CRL by factory root CA")
 	certs := client.CaCerts{CaRevokeCrl: x509.CreateCrl(toRevoke)}

--- a/subcommands/keys/ca_revoke_device_ca.go
+++ b/subcommands/keys/ca_revoke_device_ca.go
@@ -1,0 +1,99 @@
+package keys
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/foundriesio/fioctl/client"
+	"github.com/foundriesio/fioctl/subcommands"
+	"github.com/foundriesio/fioctl/x509"
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "revoke-device-ca <PKI Directory>",
+		Short: "Revoke device CA, so that devices with client certificates it issued can no longer connect to your Factory",
+		Run:   doRevokeDeviceCa,
+		Args:  cobra.ExactArgs(1),
+		Long: `Revoke device CA, so that devices with client certificates it issued can no longer connect to your Factory.
+
+When the online or local device CA is revoked:
+- It is no longer possible to register new devices with client certificates it had issued.
+- Existing devices with client certificates it issued can no longer connect to your Factory.
+
+You may later re-add a revoked device CA using "keys ca update", if you still keep its certificate stored somewhere.
+Once you do this, devices with client certificates issued by this device CA may connect to your Factory again.`,
+		Example: `
+# Revoke a local device CA by providing a (default) file name inside your PKI directory:
+fioctl keys ca revoke-device-ca /path/to/pki/dir --ca-file local-ca
+
+# Revoke two local device CAs given a full path to their files:
+fioctl keys ca revoke-device-ca /path/to/pki/dir --ca-file /path/to/ca1.pem --ca-file /path/to/ca2.crt
+
+# Revoke two device CAs given their serial numbers:
+fioctl keys ca revoke-device-ca /path/to/pki/dir --ca-serial <base-10-serial-1> --ca-file <base-10-serial-2>
+
+# Revoke a local device CA, when your factory root CA private key is stored on an HSM:
+fioctl keys ca revoke-device-ca /path/to/pki/dir --ca-file local-ca \
+  --hsm-module /path/to/pkcs11-module.so --hsm-pin 1234 --hsm-token-label <token-label-for-key>
+
+# Show a generated CRL that would be sent to the server to revoke a local device CA, without actually revoking it.
+fioctl keys ca revoke-device-ca /path/to/pki/dir --ca-file local-ca --dry-run --pretty`,
+	}
+	caCmd.AddCommand(cmd)
+	cmd.Flags().BoolP("dry-run", "", false,
+		"Do not revoke the certificate, but instead show a generated CRL that will be uploaded to the server.")
+	cmd.Flags().BoolP("pretty", "", false,
+		"Can be used with dry-run to show the generated CRL in a pretty format.")
+	cmd.Flags().StringArrayP("ca-file", "", nil,
+		"A file name of the device CA to revoke. Can be used multiple times to revoke several device CAs.")
+	cmd.Flags().StringArrayP("ca-serial", "", nil,
+		"A serial number (base 10) of the device CA to revoke. Can be used multiple times to revoke several device CAs.")
+	_ = cmd.MarkFlagFilename("ca-file")
+	// HSM variables defined in ca_create.go
+	cmd.Flags().StringVarP(&hsmModule, "hsm-module", "", "", "Load a root CA key from a PKCS#11 compatible HSM using this module")
+	cmd.Flags().StringVarP(&hsmPin, "hsm-pin", "", "", "The PKCS#11 PIN to log into the HSM")
+	cmd.Flags().StringVarP(&hsmTokenLabel, "hsm-token-label", "", "", "The label of the HSM token containing the root CA key")
+}
+
+func doRevokeDeviceCa(cmd *cobra.Command, args []string) {
+	factory := viper.GetString("factory")
+	// TODO: Implement the --dry-run and --pretty arguments
+	// dryRun, _ := cmd.Flags().GetBool("dry-run")
+	// pretty, _ := cmd.Flags().GetBool("pretty")
+	caFiles, _ := cmd.Flags().GetStringArray("ca-file")
+	caSerials, _ := cmd.Flags().GetStringArray("ca-serial")
+
+	if len(caFiles)+len(caSerials) == 0 {
+		subcommands.DieNotNil(errors.New("At least one of --ca-file or --ca-serial must be provided"))
+	}
+
+	subcommands.DieNotNil(os.Chdir(args[0]))
+	hsm, err := x509.ValidateHsmArgs(
+		hsmModule, hsmPin, hsmTokenLabel, "--hsm-module", "--hsm-pin", "--hsm-token-label")
+	subcommands.DieNotNil(err)
+	x509.InitHsm(hsm)
+
+	fmt.Println("Generating Certificate Revocation List")
+	toRevoke := make(map[string]int, len(caSerials)+len(caFiles))
+	for _, serial := range caSerials {
+		num := new(big.Int)
+		if _, ok := num.SetString(serial, 10); !ok {
+			subcommands.DieNotNil(fmt.Errorf("Value %s is not a valid base 10 serial", serial))
+		}
+		toRevoke[serial] = x509.CrlCaRevoke
+	}
+	for _, filename := range caFiles {
+		ca := x509.LoadCertFromFile(filename)
+		toRevoke[ca.SerialNumber.Text(10)] = x509.CrlCaRevoke
+	}
+	fmt.Println("Signing CRL by factory root CA")
+	certs := client.CaCerts{CaRevokeCrl: x509.CreateCrl(toRevoke)}
+	fmt.Println("Uploading CRL to Foundries.io")
+	subcommands.DieNotNil(api.FactoryPatchCA(factory, certs))
+}

--- a/subcommands/keys/ca_show.go
+++ b/subcommands/keys/ca_show.go
@@ -58,6 +58,7 @@ func doShowCA(cmd *cobra.Command, args []string) {
 			printOneCert(resp.TlsCrt)
 		case justShowCas:
 			printOneCert(resp.CaCrt)
+			printDisabledCas(resp.CaDisabled)
 		default:
 			panic("Unknown flag: " + flag)
 		}
@@ -82,6 +83,7 @@ func doShowCA(cmd *cobra.Command, args []string) {
 	printOneCert(resp.TlsCrt)
 	fmt.Println("\n## Device Authentication Certificate(s)")
 	printOneCert(resp.CaCrt)
+	printDisabledCas(resp.CaDisabled)
 }
 
 func printOneCert(crt string) {
@@ -89,6 +91,15 @@ func printOneCert(crt string) {
 		prettyPrint(crt)
 	} else {
 		fmt.Println(crt)
+	}
+}
+
+func printDisabledCas(serials []string) {
+	if len(serials) > 0 {
+		fmt.Println("\n## Disabled Device Authentication Certificate Serial(s)")
+		for _, num := range serials {
+			fmt.Println(" - ", num)
+		}
 	}
 }
 

--- a/subcommands/keys/ca_show.go
+++ b/subcommands/keys/ca_show.go
@@ -152,23 +152,30 @@ func extKeyUsage(ext []x509.ExtKeyUsage) string {
 	return vals
 }
 
-func prettyPrint(cert string) {
-	for len(cert) > 0 {
-		block, remaining := pem.Decode([]byte(cert))
+func parseCertList(pemData string) (certs []*x509.Certificate) {
+	for len(pemData) > 0 {
+		block, remaining := pem.Decode([]byte(pemData))
 		if block == nil {
 			// could be excessive whitespace
-			if cert = strings.TrimSpace(string(remaining)); len(cert) == len(remaining) {
+			if pemData = strings.TrimSpace(string(remaining)); len(pemData) == len(remaining) {
 				fmt.Println("Failed to parse remaining certificates: invalid PEM data")
 				break
 			}
 			continue
 		}
-		cert = string(remaining)
+		pemData = string(remaining)
 		c, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
 			fmt.Println("Failed to parse certificate:" + err.Error())
 			continue
 		}
+		certs = append(certs, c)
+	}
+	return
+}
+
+func prettyPrint(cert string) {
+	for _, c := range parseCertList(cert) {
 		fmt.Println("Certificate:")
 		fmt.Println("\tVersion:", c.Version)
 		fmt.Println("\tSerial Number:", c.SerialNumber.Text(10))

--- a/subcommands/keys/ca_show.go
+++ b/subcommands/keys/ca_show.go
@@ -158,7 +158,7 @@ func prettyPrint(cert string) {
 		}
 		fmt.Println("Certificate:")
 		fmt.Println("\tVersion:", c.Version)
-		fmt.Println("\tSerial Number:", c.SerialNumber)
+		fmt.Println("\tSerial Number:", c.SerialNumber.Text(10))
 		fmt.Println("\tSignature Algorithm:", c.SignatureAlgorithm)
 		fmt.Println("\tIssuer:", c.Issuer)
 		fmt.Println("\tValidity")

--- a/subcommands/keys/ca_show.go
+++ b/subcommands/keys/ca_show.go
@@ -157,7 +157,10 @@ func prettyPrint(cert string) {
 		block, remaining := pem.Decode([]byte(cert))
 		if block == nil {
 			// could be excessive whitespace
-			cert = strings.TrimSpace(string(remaining))
+			if cert = strings.TrimSpace(string(remaining)); len(cert) == len(remaining) {
+				fmt.Println("Failed to parse remaining certificates: invalid PEM data")
+				break
+			}
 			continue
 		}
 		cert = string(remaining)

--- a/x509/bash.go
+++ b/x509/bash.go
@@ -159,6 +159,13 @@ func SignEl2GoCsr(csrPem string) string {
 	return signCaCsr("el2g-*", csrPem)
 }
 
+func CreateCrl(serials map[string]int) string {
+	if true {
+		panic("This function is not implemented in Bash implementation")
+	}
+	return "Neverland"
+}
+
 func signTlsCsr(tmpFileMask, csrPem string) string {
 	const script = `#!/bin/sh -e
 ## This script signs the "tls-csr" returned when creating Factory certificates.

--- a/x509/bash.go
+++ b/x509/bash.go
@@ -67,7 +67,7 @@ OU = ${ou}
 
 [ext]
 basicConstraints=CA:TRUE
-keyUsage = keyCertSign
+keyUsage = keyCertSign, cRLSign
 extendedKeyUsage = critical, clientAuth, serverAuth
 EOF
 

--- a/x509/common.go
+++ b/x509/common.go
@@ -29,6 +29,15 @@ const (
 	// Note: the API will revoke the CA for any reason other than 6 or 8.
 	// This action is permanent.
 	CrlCaRevoke = 9 // RFC 5280 - privilegeWithdrawn
+
+	// Disable the device CA, so that no new devices can be registered with client certificates issued by this CA.
+	// Devices that were already registered can still connect and operate as normal.
+	// This action can be reverted by CrlCaRenew.
+	CrlCaDisable = 6 // RFC 5280 - certificateHold
+
+	// Renew the previously disabled device CA, so that new device registrations are possible again.
+	// This value is currently not used by Fioctl. It is here for the reference of API integrators.
+	CrlCaRenew = 8 // RFC 5280 - removeFromCRL
 )
 
 func readFile(filename string) string {

--- a/x509/common.go
+++ b/x509/common.go
@@ -22,6 +22,15 @@ const (
 	factoryCaName string = "Factory-CA"
 )
 
+const (
+	// CRL constants for device CA revokation.
+
+	// Revoke the device CA, so that no device client certificates issued by this CA are recognized.
+	// Note: the API will revoke the CA for any reason other than 6 or 8.
+	// This action is permanent.
+	CrlCaRevoke = 9 // RFC 5280 - privilegeWithdrawn
+)
+
 func readFile(filename string) string {
 	data, err := os.ReadFile(filename)
 	subcommands.DieNotNil(err)

--- a/x509/common.go
+++ b/x509/common.go
@@ -1,6 +1,9 @@
 package x509
 
 import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 
@@ -64,4 +67,19 @@ func ValidateHsmArgs(hsmModule, hsmPin, hsmTokenLabel, moduleArg, pinArg, tokenA
 		return &HsmInfo{Module: hsmModule, Pin: hsmPin, TokenLabel: hsmTokenLabel}, nil
 	}
 	return nil, nil
+}
+
+func parseOnePemBlock(pemBlock string) *pem.Block {
+	first, rest := pem.Decode([]byte(pemBlock))
+	if first == nil || len(rest) > 0 {
+		subcommands.DieNotNil(errors.New("Malformed PEM data"))
+	}
+	return first
+}
+
+func LoadCertFromFile(fn string) *x509.Certificate {
+	crtPem := parseOnePemBlock(readFile(fn))
+	crt, err := x509.ParseCertificate(crtPem.Bytes)
+	subcommands.DieNotNil(err)
+	return crt
 }

--- a/x509/common_test.go
+++ b/x509/common_test.go
@@ -88,7 +88,7 @@ func runTest(t *testing.T, verifyFiles func(factoryCa, tlsCert, onlineCa, offlin
 	assert.Nil(t, err)
 
 	assert.Equal(t, true, factoryCa.IsCA)
-	assert.Equal(t, x509.KeyUsageCertSign, factoryCa.KeyUsage)
+	assert.Equal(t, x509.KeyUsageCertSign|x509.KeyUsageCRLSign, factoryCa.KeyUsage)
 	assert.Equal(t, factoryCaName, factoryCa.Subject.CommonName)
 	assert.Equal(t, []string{testFactory}, factoryCa.Subject.OrganizationalUnit)
 	assert.Equal(t, [][]*x509.Certificate{{factoryCa}}, factoryCaChain)

--- a/x509/golang.go
+++ b/x509/golang.go
@@ -136,6 +136,42 @@ func SignEstCsr(csrPem string) string {
 	return genTlsCert(csr.Subject, csr.DNSNames, csr.PublicKey)
 }
 
+var oidExtensionReasonCode = []int{2, 5, 29, 21}
+
+func CreateCrl(serials map[string]int) string {
+	factoryKey := factoryCaKeyStorage.loadKey()
+	factoryCa := LoadCertFromFile(FactoryCaCertFile)
+	now := time.Now()
+	crl := &x509.RevocationList{
+		Number:     big.NewInt(1),
+		ThisUpdate: now,
+		NextUpdate: now.Add(time.Minute * 15),
+	}
+	for serial, reason := range serials {
+		num := new(big.Int)
+		if _, ok := num.SetString(serial, 10); !ok {
+			// We expect a valid input here
+			panic("Value is not a valid base 10 serial:" + serial)
+		}
+		// This would be easier with RevokedCertificateEntries, but it is not yet available in Golang 1.20.
+		reasonBytes, err := asn1.Marshal(asn1.Enumerated(reason))
+		subcommands.DieNotNil(err)
+
+		crl.RevokedCertificates = append(crl.RevokedCertificates, pkix.RevokedCertificate{
+			SerialNumber:   num,
+			RevocationTime: now,
+			Extensions:     []pkix.Extension{{Id: oidExtensionReasonCode, Value: reasonBytes}},
+		})
+	}
+	derBytes, err := x509.CreateRevocationList(rand.Reader, crl, factoryCa, factoryKey)
+	subcommands.DieNotNil(err)
+
+	var pemBuffer bytes.Buffer
+	err = pem.Encode(&pemBuffer, &pem.Block{Type: "X509 CRL", Bytes: derBytes})
+	subcommands.DieNotNil(err)
+	return pemBuffer.String()
+}
+
 func genTlsCert(subject pkix.Name, dnsNames []string, pubkey crypto.PublicKey) string {
 	factoryKey := factoryCaKeyStorage.loadKey()
 	factoryCa := LoadCertFromFile(FactoryCaCertFile)

--- a/x509/golang.go
+++ b/x509/golang.go
@@ -10,7 +10,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/pem"
-	"errors"
 	"math/big"
 	"time"
 
@@ -42,14 +41,6 @@ func genCertificate(
 	subcommands.DieNotNil(err)
 
 	return certRow.String()
-}
-
-func parseOnePemBlock(pemBlock string) *pem.Block {
-	first, rest := pem.Decode([]byte(pemBlock))
-	if first == nil || len(rest) > 0 {
-		subcommands.DieNotNil(errors.New("Malformed PEM data"))
-	}
-	return first
 }
 
 func parsePemCertificateRequest(csrPem string) *x509.CertificateRequest {
@@ -147,7 +138,7 @@ func SignEstCsr(csrPem string) string {
 
 func genTlsCert(subject pkix.Name, dnsNames []string, pubkey crypto.PublicKey) string {
 	factoryKey := factoryCaKeyStorage.loadKey()
-	factoryCa := loadCertFromFile(FactoryCaCertFile)
+	factoryCa := LoadCertFromFile(FactoryCaCertFile)
 	crtTemplate := x509.Certificate{
 		SerialNumber: genRandomSerialNumber(),
 		Subject:      subject,
@@ -165,7 +156,7 @@ func genTlsCert(subject pkix.Name, dnsNames []string, pubkey crypto.PublicKey) s
 
 func genCaCert(subject pkix.Name, pubkey crypto.PublicKey) string {
 	factoryKey := factoryCaKeyStorage.loadKey()
-	factoryCa := loadCertFromFile(FactoryCaCertFile)
+	factoryCa := LoadCertFromFile(FactoryCaCertFile)
 	crtTemplate := x509.Certificate{
 		SerialNumber: genRandomSerialNumber(),
 		Subject:      subject,

--- a/x509/golang.go
+++ b/x509/golang.go
@@ -93,7 +93,7 @@ func CreateFactoryCa(ou string) string {
 
 		BasicConstraintsValid: true,
 		IsCA:                  true,
-		KeyUsage:              x509.KeyUsageCertSign,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	}
 	factoryCaString := genCertificate(&crtTemplate, &crtTemplate, priv.Public(), priv)
@@ -163,6 +163,8 @@ func CreateCrl(serials map[string]int) string {
 			Extensions:     []pkix.Extension{{Id: oidExtensionReasonCode, Value: reasonBytes}},
 		})
 	}
+	// Our old root CAs are missing this bit; it's OK to add this here, and the API will accept it.
+	factoryCa.KeyUsage |= x509.KeyUsageCRLSign
 	derBytes, err := x509.CreateRevocationList(rand.Reader, crl, factoryCa, factoryKey)
 	subcommands.DieNotNil(err)
 

--- a/x509/storage_filesystem.go
+++ b/x509/storage_filesystem.go
@@ -33,13 +33,6 @@ func loadKeyFromFile(fn string) crypto.Signer {
 	return key
 }
 
-func loadCertFromFile(fn string) *x509.Certificate {
-	crtPem := parseOnePemBlock(readFile(fn))
-	crt, err := x509.ParseCertificate(crtPem.Bytes)
-	subcommands.DieNotNil(err)
-	return crt
-}
-
 func (s *fileStorage) genAndSaveKey() crypto.Signer {
 	return genAndSaveKeyToFile(s.Filename)
 }


### PR DESCRIPTION
Currently, an API allows to simply remove the device CA from a list of CAs.

This change implements the device CA removal via the X.509 certificate revocation.
That way, a user is required to crypto-sign the operation using the factory root CA.
Thus, we both obtain an cryptographic conscent from the user for this operation and protect against several scenarios:
- An accidental device CA removal by passing a wrong file to "keys ca update".
- An intentional device CA removal by bad admin who does not possess the factory root CA.

After this change, the API will be changed to require the "ca-crt" field to contain all device CAs which:
- Are already present in the "ca-crt" list on the backend.
- And are not explicitly listed in the "ca-revoke-crl" list.

There are two new operations introduced:
- *disable device CA*: Tell the backend to disallow registering new devices using this CA; already registered devices (using this CA) can still connect and use FoundriesFactory.
- *revoke device CA*: Tell the backend to remove this CA from the list of trusted device CAs; devices with client certs issued by this CA can no longer connect and use FoundriesFactory.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>