### PR TITLE
feat(login): better defaults for custom URLs

### DIFF
--- a/subcommands/login/cmd.go
+++ b/subcommands/login/cmd.go
@@ -45,7 +45,12 @@ func doLogin(cmd *cobra.Command, args []string) {
 		subcommands.SaveOauthConfig(creds.Config)
 		return
 	}
-
+	if !cmd.Flag("oauth-url").Changed {
+		authURL = subcommands.Config.ClientCredentials.URL
+	}
+	if len(authURL) == 0 {
+		authURL = client.OauthURL
+	}
 	u, err := url.Parse(authURL)
 	subcommands.DieNotNil(err)
 	subcommands.Config.ClientCredentials.URL = authURL


### PR DESCRIPTION
Just a simple way of shifting the way the default URL gets set.

If the command line switch is given, then use that URL. 
Otherwise if a config URL is already set, use that URL.
Otherwise fallback to the default we were using previously.