### PR TITLE
Hotfix: clean up key owners when rotating TUF keys

### DIFF
--- a/subcommands/keys/tuf_utils.go
+++ b/subcommands/keys/tuf_utils.go
@@ -354,6 +354,7 @@ func removeUnusedTufKeys(root *client.AtsTufRoot) {
 		if !found {
 			fmt.Println("= Removing unused key:", k)
 			delete(root.Signed.Keys, k)
+			delete(root.Signed.KeyOwners, k)
 		}
 	}
 }


### PR DESCRIPTION
This is an important hot fix.
Currently, the API fails on subsequent key rotations due to denying old key owners.

Fortunately, customers should not see it, as the first rotation succeeds. But, when the user wants to rotate the key which was rotated using new Fioctl - that second rotation fails.