### PR TITLE
Feature: re-sign all active waves on TUF targets key rotation

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -1583,9 +1583,9 @@ func (a *Api) FactoryCreateWave(factory string, wave *WaveCreate) error {
 	return err
 }
 
-func (a *Api) FactoryListWaves(factory string, limit, page uint64) (*WaveList, error) {
-	url := fmt.Sprintf("%s/ota/factories/%s/waves/?limit=%d&page=%d",
-		a.serverUrl, factory, limit, page)
+func (a *Api) FactoryListWaves(factory string, limit, page uint64, onlyActive bool) (*WaveList, error) {
+	url := fmt.Sprintf("%s/ota/factories/%s/waves/?limit=%d&page=%d&only-active=%t",
+		a.serverUrl, factory, limit, page, onlyActive)
 	logrus.Debugf("Listing factory waves %s", url)
 
 	body, err := a.Get(url)

--- a/client/foundries.go
+++ b/client/foundries.go
@@ -1682,7 +1682,16 @@ func (a *Api) FactoryWaveStatus(factory string, wave string, inactiveThreshold i
 func (a *Api) ProdTargetsList(factory string, failNotExist bool, tags ...string) (map[string]AtsTufTargets, error) {
 	url := a.serverUrl + "/ota/factories/" + factory + "/prod-targets/?tag=" + strings.Join(tags, ",")
 	logrus.Debugf("Fetching factory production targets %s", url)
+	return a.prodTargetsList(url, failNotExist)
+}
 
+func (a *Api) WaveTargetsList(factory string, failNotExist bool, names ...string) (map[string]AtsTufTargets, error) {
+	url := a.serverUrl + "/ota/factories/" + factory + "/wave-targets/?name=" + strings.Join(names, ",")
+	logrus.Debugf("Fetching factory production wave targets %s", url)
+	return a.prodTargetsList(url, failNotExist)
+}
+
+func (a *Api) prodTargetsList(url string, failNotExist bool) (map[string]AtsTufTargets, error) {
 	body, err := a.Get(url)
 	if err != nil {
 		if !failNotExist {

--- a/client/foundries.go
+++ b/client/foundries.go
@@ -770,7 +770,7 @@ func (a *Api) DeviceGet(factory, device string) (*Device, error) {
 }
 
 func (a *Api) DeviceList(
-	mine bool, matchTag, byFactory, byGroup, nameIlike, uuid, byTarget, sortBy string, page, limit int,
+	mine bool, matchTag, byFactory, byGroup, nameIlike, uuid, byTarget, sortBy string, page, limit uint64,
 ) (*DeviceList, error) {
 	mineInt := 0
 	if mine {
@@ -799,7 +799,7 @@ func (a *Api) DeviceListCont(url string) (*DeviceList, error) {
 	return &devices, nil
 }
 
-func (a *Api) DeviceListDenied(factory string, page, limit int) (*DeviceList, error) {
+func (a *Api) DeviceListDenied(factory string, page, limit uint64) (*DeviceList, error) {
 	url := a.serverUrl + "/ota/factories/" + factory + "/denied-devices/"
 	url += fmt.Sprintf("?limit=%d&page=%d", limit, page)
 	return a.DeviceListCont(url)
@@ -1583,8 +1583,9 @@ func (a *Api) FactoryCreateWave(factory string, wave *WaveCreate) error {
 	return err
 }
 
-func (a *Api) FactoryListWaves(factory string, limit uint64, page int) (*WaveList, error) {
-	url := a.serverUrl + "/ota/factories/" + factory + "/waves/?limit=" + strconv.FormatUint(limit, 10) + "&page=" + strconv.Itoa(page)
+func (a *Api) FactoryListWaves(factory string, limit, page uint64) (*WaveList, error) {
+	url := fmt.Sprintf("%s/ota/factories/%s/waves/?limit=%d&page=%d",
+		a.serverUrl, factory, limit, page)
 	logrus.Debugf("Listing factory waves %s", url)
 
 	body, err := a.Get(url)

--- a/client/foundries_tuf_root.go
+++ b/client/foundries_tuf_root.go
@@ -181,15 +181,16 @@ func (a *Api) TufRootUpdatesInit(
 }
 
 func (a *Api) TufRootUpdatesPut(
-	factory, txid string, ciRoot, prodRoot *AtsTufRoot, targetsSigs map[string][]tuf.Signature,
+	factory, txid string, ciRoot, prodRoot *AtsTufRoot, targetsProdSigs, targetsWaveSigs map[string][]tuf.Signature,
 ) (err error) {
 	url := a.serverUrl + "/ota/repo/" + factory + "/api/v1/user_repo/root/updates"
 	data, _ := json.Marshal(struct {
-		TransactionId     string                     `json:"txid"`
-		CiRoot            *AtsTufRoot                `json:"ci-root"`
-		ProdRoot          *AtsTufRoot                `json:"prod-root"`
-		TargetsSignatures map[string][]tuf.Signature `json:"targets-signatures,omitempty"`
-	}{txid, ciRoot, prodRoot, targetsSigs})
+		TransactionId   string                     `json:"txid"`
+		CiRoot          *AtsTufRoot                `json:"ci-root"`
+		ProdRoot        *AtsTufRoot                `json:"prod-root"`
+		TargetsProdSigs map[string][]tuf.Signature `json:"targets-signatures,omitempty"`
+		TargetsWaveSigs map[string][]tuf.Signature `json:"waves-signatures,omitempty"`
+	}{txid, ciRoot, prodRoot, targetsProdSigs, targetsWaveSigs})
 	_, err = a.Put(url, data)
 	return
 }

--- a/subcommands/common.go
+++ b/subcommands/common.go
@@ -269,7 +269,7 @@ func FindWritableDirInPath(helperPath string) string {
 	return ""
 }
 
-func ShowPages(showPage int, next *string) {
+func ShowPages(showPage uint64, next *string) {
 	if next != nil {
 		fmt.Print("\nNext page can be viewed with: ")
 		found := false

--- a/subcommands/devices/list.go
+++ b/subcommands/devices/list.go
@@ -24,9 +24,9 @@ var (
 	deviceInactiveHours int
 	deviceUuid          string
 	showColumns         []string
-	showPage            int
-	paginationLimit     int
-	paginationLimits    []int
+	showPage            uint64
+	paginationLimit     uint64
+	paginationLimits    []uint64
 )
 
 type column struct {
@@ -90,17 +90,17 @@ var Columns = map[string]column{
 }
 
 func addPaginationFlags(cmd *cobra.Command) {
-	paginationLimits = []int{10, 20, 30, 40, 50, 100, 200, 500, 1000}
+	paginationLimits = []uint64{10, 20, 30, 40, 50, 100, 200, 500, 1000}
 	limitsStr := ""
 	for i, limit := range paginationLimits {
 		if i > 0 {
 			limitsStr += ","
 		}
-		limitsStr += strconv.Itoa(limit)
+		limitsStr += strconv.FormatUint(limit, 10)
 	}
 
-	cmd.Flags().IntVarP(&showPage, "page", "p", 1, "Page of devices to display when pagination is needed")
-	cmd.Flags().IntVarP(&paginationLimit, "limit", "n", 500, "Number of devices to paginate by. Allowed values: "+limitsStr)
+	cmd.Flags().Uint64VarP(&showPage, "page", "p", 1, "Page of devices to display when pagination is needed")
+	cmd.Flags().Uint64VarP(&paginationLimit, "limit", "n", 500, "Number of devices to paginate by. Allowed values: "+limitsStr)
 }
 
 func addSortFlag(cmd *cobra.Command, flag, short, help string) {

--- a/subcommands/keys/tuf_resign_root.go
+++ b/subcommands/keys/tuf_resign_root.go
@@ -53,7 +53,7 @@ func doResignRoot(cmd *cobra.Command, args []string) {
 	signNewTufRoot(curCiRoot, newCiRoot, newProdRoot, creds)
 
 	fmt.Println("= Uploading new TUF root")
-	subcommands.DieNotNil(api.TufRootUpdatesPut(factory, "", newCiRoot, newProdRoot, nil))
+	subcommands.DieNotNil(api.TufRootUpdatesPut(factory, "", newCiRoot, newProdRoot, nil, nil))
 
 	fmt.Println("= Applying staged TUF root changes")
 	tufUpdatesCmd.SetArgs([]string{"apply"})

--- a/subcommands/keys/tuf_updates_add_offline_key.go
+++ b/subcommands/keys/tuf_updates_add_offline_key.go
@@ -85,7 +85,7 @@ func doTufUpdatesAddOfflineKey(cmd *cobra.Command, args []string) {
 
 	fmt.Println("= Uploading new TUF root")
 	tmpFile := saveTempTufCreds(keysFile, creds)
-	err = api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, nil)
+	err = api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, nil, nil)
 	handleTufRootUpdatesUpload(tmpFile, keysFile, err)
 }
 

--- a/subcommands/keys/tuf_updates_delete_offline_key.go
+++ b/subcommands/keys/tuf_updates_delete_offline_key.go
@@ -115,5 +115,5 @@ func doTufUpdatesDeleteOfflineKey(cmd *cobra.Command, args []string) {
 	newCiRoot, newProdRoot = finalizeTufRootChanges(newCiRoot, newProdRoot)
 
 	fmt.Println("= Uploading new TUF root")
-	subcommands.DieNotNil(api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, nil))
+	subcommands.DieNotNil(api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, nil, nil))
 }

--- a/subcommands/keys/tuf_updates_rotate_offline_key.go
+++ b/subcommands/keys/tuf_updates_rotate_offline_key.go
@@ -110,7 +110,7 @@ func doTufUpdatesRotateOfflineRootKey(cmd *cobra.Command) {
 
 	fmt.Println("= Uploading new TUF root")
 	tmpFile := saveTempTufCreds(keysFile, newCreds)
-	err = api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, nil)
+	err = api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, nil, nil)
 	handleTufRootUpdatesUpload(tmpFile, keysFile, err)
 }
 
@@ -207,7 +207,7 @@ outerLoop:
 
 	fmt.Println("= Uploading new TUF root")
 	tmpFile := saveTempTufCreds(targetsKeysFile, newCreds)
-	err = api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, newTargetsSigs)
+	err = api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, newTargetsSigs, nil)
 	handleTufRootUpdatesUpload(tmpFile, targetsKeysFile, err)
 }
 

--- a/subcommands/keys/tuf_updates_rotate_online_key.go
+++ b/subcommands/keys/tuf_updates_rotate_online_key.go
@@ -87,6 +87,6 @@ func doTufUpdatesRotateOnlineKey(cmd *cobra.Command, args []string) {
 		signNewTufRoot(curCiRoot, newCiRoot, newProdRoot, creds)
 
 		fmt.Println("= Uploading new TUF root")
-		subcommands.DieNotNil(api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, nil))
+		subcommands.DieNotNil(api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, nil, nil))
 	}
 }

--- a/subcommands/keys/tuf_updates_set_threshold.go
+++ b/subcommands/keys/tuf_updates_set_threshold.go
@@ -79,5 +79,5 @@ func doTufUpdatesSetThreshold(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Println("= Uploading new TUF root")
-	subcommands.DieNotNil(api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, nil))
+	subcommands.DieNotNil(api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, nil, nil))
 }

--- a/subcommands/keys/tuf_updates_sign.go
+++ b/subcommands/keys/tuf_updates_sign.go
@@ -43,5 +43,5 @@ func doTufUpdatesSign(cmd *cobra.Command, args []string) {
 	signNewTufRoot(curCiRoot, newCiRoot, newProdRoot, creds)
 
 	fmt.Println("= Uploading new TUF root")
-	subcommands.DieNotNil(api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, nil))
+	subcommands.DieNotNil(api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, nil, nil))
 }

--- a/subcommands/keys/tuf_updates_sign_prod_targets.go
+++ b/subcommands/keys/tuf_updates_sign_prod_targets.go
@@ -72,5 +72,5 @@ For example, add a new offline TUF targets key, before signing production target
 	subcommands.DieNotNil(err)
 
 	fmt.Println("= Uploading new signatures")
-	subcommands.DieNotNil(api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, newTargetsSigs))
+	subcommands.DieNotNil(api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, newTargetsSigs, nil))
 }

--- a/subcommands/keys/tuf_updates_sign_prod_targets.go
+++ b/subcommands/keys/tuf_updates_sign_prod_targets.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"golang.org/x/exp/slices"
 
-	"github.com/foundriesio/fioctl/client"
 	"github.com/foundriesio/fioctl/subcommands"
 )
 
@@ -68,11 +66,9 @@ For example, add a new offline TUF targets key, before signing production target
 	subcommands.DieNotNil(err)
 
 	fmt.Println("= Signing prod targets")
-	newTargetsSigs, err := signProdTargets(factory, signer,
-		func(tag string, targets client.AtsTufTargets) bool {
-			return tags != nil && !slices.Contains(tags, tag)
-		},
-	)
+	targetsMap, err := api.ProdTargetsList(factory, false, tags...)
+	subcommands.DieNotNil(err, "Failed to fetch production targets:")
+	newTargetsSigs, err := signProdTargets(signer, targetsMap)
 	subcommands.DieNotNil(err)
 
 	fmt.Println("= Uploading new signatures")

--- a/subcommands/keys/tuf_updates_sign_prod_targets.go
+++ b/subcommands/keys/tuf_updates_sign_prod_targets.go
@@ -66,7 +66,7 @@ For example, add a new offline TUF targets key, before signing production target
 	subcommands.DieNotNil(err)
 
 	fmt.Println("= Signing prod targets")
-	targetsMap, err := api.ProdTargetsList(factory, false, tags...)
+	targetsMap, err := api.ProdTargetsList(factory, true, tags...)
 	subcommands.DieNotNil(err, "Failed to fetch production targets:")
 	newTargetsSigs, err := signProdTargets(signer, targetsMap)
 	subcommands.DieNotNil(err)

--- a/subcommands/keys/tuf_updates_sign_prod_targets.go
+++ b/subcommands/keys/tuf_updates_sign_prod_targets.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	tuf "github.com/theupdateframework/notary/tuf/data"
 
 	"github.com/foundriesio/fioctl/subcommands"
 )
@@ -32,6 +33,7 @@ There are 3 use cases when this command comes handy:
 	_ = signCmd.MarkFlagFilename("keys")
 	_ = signCmd.MarkFlagRequired("keys")
 	signCmd.Flags().StringP("tags", "", "", "A comma-separated list of tags to sign; default: all tags.")
+	signCmd.Flags().StringP("waves", "", "", "A comma-separated list of waves to sign; default: all active waves.")
 	tufUpdatesCmd.AddCommand(signCmd)
 }
 
@@ -40,9 +42,13 @@ func doTufUpdatesSignProdTargets(cmd *cobra.Command, args []string) {
 	txid, _ := cmd.Flags().GetString("txid")
 	keysFile, _ := cmd.Flags().GetString("keys")
 	tagsStr, _ := cmd.Flags().GetString("tags")
-	var tags []string
+	wavesStr, _ := cmd.Flags().GetString("waves")
+	var tags, waveNames []string
 	if tagsStr != "" {
 		tags = strings.Split(tagsStr, ",")
+	}
+	if wavesStr != "" {
+		waveNames = strings.Split(wavesStr, ",")
 	}
 
 	creds, err := GetOfflineCreds(keysFile)
@@ -65,12 +71,25 @@ For example, add a new offline TUF targets key, before signing production target
 		subcommands.SliceRemove(newCiRoot.Signed.Roles["targets"].KeyIDs, onlineTargetsId))
 	subcommands.DieNotNil(err)
 
+	var newTargetsProdSigs, newTargetsWaveSigs map[string][]tuf.Signature
+
 	fmt.Println("= Signing prod targets")
-	targetsMap, err := api.ProdTargetsList(factory, true, tags...)
-	subcommands.DieNotNil(err, "Failed to fetch production targets:")
-	newTargetsSigs, err := signProdTargets(signer, targetsMap)
-	subcommands.DieNotNil(err)
+	// If both wave names and tags specified, or none specified - re-sign both prod and wave targets.
+	// If only wave names or only tags specified - re-sign only what was specified (either wave names or tags).
+	if len(tags) > 0 || len(waveNames) == 0 {
+		targetsProdMap, err := api.ProdTargetsList(factory, true, tags...)
+		subcommands.DieNotNil(err, "Failed to fetch production targets:")
+		newTargetsProdSigs, err = signProdTargets(signer, targetsProdMap)
+		subcommands.DieNotNil(err)
+	}
+	if len(waveNames) > 0 || len(tags) == 0 {
+		targetsWaveMap, err := api.WaveTargetsList(factory, true, waveNames...)
+		subcommands.DieNotNil(err, "Failed to fetch production wave targets:")
+		newTargetsWaveSigs, err = signProdTargets(signer, targetsWaveMap)
+		subcommands.DieNotNil(err)
+	}
 
 	fmt.Println("= Uploading new signatures")
-	subcommands.DieNotNil(api.TufRootUpdatesPut(factory, txid, newCiRoot, newProdRoot, newTargetsSigs, nil))
+	subcommands.DieNotNil(api.TufRootUpdatesPut(
+		factory, txid, newCiRoot, newProdRoot, newTargetsProdSigs, newTargetsWaveSigs))
 }

--- a/subcommands/keys/tuf_utils.go
+++ b/subcommands/keys/tuf_utils.go
@@ -454,20 +454,10 @@ func signNewTufRoot(curCiRoot, newCiRoot, newProdRoot *client.AtsTufRoot, creds 
 }
 
 func signProdTargets(
-	factory string, signer TufSigner, excludeFunc func(string, client.AtsTufTargets) bool,
+	signer TufSigner, targetsMap map[string]client.AtsTufTargets,
 ) (map[string][]tuf.Signature, error) {
-	targetsMap, err := api.ProdTargetsList(factory, false)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch production targets: %w", err)
-	} else if targetsMap == nil {
-		return nil, nil
-	}
-
-	signatureMap := make(map[string][]tuf.Signature)
+	signatureMap := make(map[string][]tuf.Signature, len(targetsMap))
 	for tag, targets := range targetsMap {
-		if excludeFunc != nil && excludeFunc(tag, targets) {
-			continue
-		}
 		bytes, err := canonical.MarshalCanonical(targets.Signed)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to marshal targets for tag %s: %w", tag, err)

--- a/subcommands/waves/list.go
+++ b/subcommands/waves/list.go
@@ -17,13 +17,13 @@ func init() {
 	}
 	cmd.AddCommand(listCmd)
 	listCmd.Flags().Uint64P("limit", "n", 20, "Limit the number of results displayed.")
-	listCmd.Flags().IntP("page", "p", 1, "Page of waves to display when pagination is needed")
+	listCmd.Flags().Uint64P("page", "p", 1, "Page of waves to display when pagination is needed")
 }
 
 func doListWaves(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
 	limit, _ := cmd.Flags().GetUint64("limit")
-	showPage, _ := cmd.Flags().GetInt("page")
+	showPage, _ := cmd.Flags().GetUint64("page")
 	logrus.Debugf("Showing a list of waves for %s", factory)
 
 	lst, err := api.FactoryListWaves(factory, limit, showPage)

--- a/subcommands/waves/list.go
+++ b/subcommands/waves/list.go
@@ -18,15 +18,17 @@ func init() {
 	cmd.AddCommand(listCmd)
 	listCmd.Flags().Uint64P("limit", "n", 20, "Limit the number of results displayed.")
 	listCmd.Flags().Uint64P("page", "p", 1, "Page of waves to display when pagination is needed")
+	listCmd.Flags().BoolP("only-active", "", false, "Only show currently active waves")
 }
 
 func doListWaves(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
 	limit, _ := cmd.Flags().GetUint64("limit")
 	showPage, _ := cmd.Flags().GetUint64("page")
+	onlyActive, _ := cmd.Flags().GetBool("only-active")
 	logrus.Debugf("Showing a list of waves for %s", factory)
 
-	lst, err := api.FactoryListWaves(factory, limit, showPage)
+	lst, err := api.FactoryListWaves(factory, limit, showPage, onlyActive)
 	subcommands.DieNotNil(err)
 
 	t := tabby.New()


### PR DESCRIPTION
This is a set of improvements using the new APIs:

- Ability to show only active waves using `waves list --only-active`.
- Ability to auto-re-sign active waves targets when running `keys tuf updates rotate-offline-key -r targets`.
- Ability to manually re-sign selected waves using `keys tuf updates sign-prod-targets --waves=<wave-list>`.
- Detect when user tries to re-sign non-existing prod targets tag using `keys tuf updates sign-prod-targets --tags=<tag-list>`.
- Verify that all `page, limit` arguments are non-negative numbers in `devices list, devices list-denied, waves list`.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>