### PR TITLE
offline-update: Add multi-target bundle support

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -1172,20 +1172,24 @@ func (a *Api) TufMetadataGet(factory string, metadata string, tag string, prod b
 	return a.Get(url)
 }
 
-func (a *Api) TufTargetMetadataRefresh(factory string, target string, tag string, expiresIn int, prod bool, wave string) (map[string]tuf.Signed, error) {
+func (a *Api) TufTargetMetadataRefresh(
+	factory string, target string, tag string, expiresIn int, prod bool, wave string, bundleTargets *tuf.Signed,
+) (map[string]tuf.Signed, error) {
 	url := a.serverUrl + "/ota/factories/" + factory + "/targets/" + target + "/meta/"
 	type targetMeta struct {
-		Tag       string `json:"tag"`
-		ExpiresIn int    `json:"expires-in-days"`
-		Prod      bool   `json:"production"`
-		Wave      string `json:"wave"`
+		Tag           string      `json:"tag"`
+		ExpiresIn     int         `json:"expires-in-days"`
+		Prod          bool        `json:"production"`
+		Wave          string      `json:"wave"`
+		BundleTargets *tuf.Signed `json:"bundle-targets,omitempty"`
 	}
 
 	b, err := json.Marshal(targetMeta{
-		Tag:       tag,
-		ExpiresIn: expiresIn,
-		Prod:      prod,
-		Wave:      wave,
+		Tag:           tag,
+		ExpiresIn:     expiresIn,
+		Prod:          prod,
+		Wave:          wave,
+		BundleTargets: bundleTargets,
 	})
 	if err != nil {
 		return nil, err

--- a/subcommands/targets/offline-update.go
+++ b/subcommands/targets/offline-update.go
@@ -198,6 +198,7 @@ Notice that multiple targets in the same directory is only supported in LmP >= v
 		}
 		fmt.Println("Successfully downloaded offline update content")
 	}
+	doShowBundle(cmd, []string{dstDir})
 }
 
 func getTargetInfo(targetFile *tuf.FileMeta) (*ouTargetInfo, error) {
@@ -489,6 +490,7 @@ func doSignBundle(cmd *cobra.Command, args []string) {
 	} else {
 		subcommands.DieNotNil(err)
 	}
+	doShowBundle(cmd, args)
 }
 
 func getLatestRoot(bundleTufPath string) (*client.AtsTufRoot, error) {


### PR DESCRIPTION
Add a proper support of multi-target bundles with all required checking and security. It is achieved by adding an additional signed metadata file/json that contains an info about a bundle's targets.

- Send `bundle-targets.json` to the `target/meta` handler if exists.
- Receive and store the bundle targets meta if the handler returns them.

The `bundle-targets.json` will be used by the offline updater to determine targets that can be installed by using a given bundle.