### PR TITLE
Pinning go version 1.20 which is the same used to release

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.19'
+          go-version: '~1.20'
 
       - name: Build All Binaries
         run: make build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.19'
+          go-version: '~1.20'
       - name: Clone the code
         uses: actions/checkout@v4
       - name: Install linter

--- a/.github/workflows/test-pki.yml
+++ b/.github/workflows/test-pki.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.19'
+          go-version: '~1.20'
       - name: Clone the code
         uses: actions/checkout@v4
       - name: Setup test deps

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/foundriesio/fioctl
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/pubsub v1.36.1


### PR DESCRIPTION
Note that we are using go 1.20 to do the release (https://github.com/foundriesio/fioctl/blob/main/.github/workflows/release.yml#L21) but all other places still pinning go 1.19. 
So, this PR ensure that we are using go 1.20 across all places

Tests made locally
- build
- login with oauth URL to fioed
- list waves for a facotry



Signed-off-by: Camila Macedo <camila.macedo@foundries.io>