### PR TITLE
Deprecation: remove re-installing fields from factory/wave status

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -207,10 +207,9 @@ type JobservRun struct {
 }
 
 type TargetStatus struct {
-	Version      int  `json:"version"`
-	Devices      int  `json:"devices"`
-	Reinstalling int  `json:"(re-)installing"`
-	IsOrphan     bool `json:"is-orphan"`
+	Version  int  `json:"version"`
+	Devices  int  `json:"devices"`
+	IsOrphan bool `json:"is-orphan"`
 }
 
 type DeviceGroupStatus struct {
@@ -219,7 +218,6 @@ type DeviceGroupStatus struct {
 	DevicesOnline   int    `json:"devices-online"`
 	DevicesOnLatest int    `json:"devices-on-latest"`
 	DevicesOnOrphan int    `json:"devices-on-orphan"`
-	Reinstalling    int    `json:"(re-)installing"`
 }
 
 type TagStatus struct {

--- a/subcommands/status/cmd.go
+++ b/subcommands/status/cmd.go
@@ -83,7 +83,7 @@ func printTargetStatus(tagPrefix string, tagStatus []client.TagStatus) {
 			name = "(Untagged)"
 		}
 		fmt.Printf("\n## %s Tag: %s\n", tagPrefix, name)
-		t := subcommands.Tabby(1, "TARGET", "DEVICES", "INSTALLING", "DETAILS")
+		t := subcommands.Tabby(1, "TARGET", "DEVICES", "DETAILS")
 		for _, tgt := range tag.Targets {
 			var orphan, details string
 			if tgt.IsOrphan {
@@ -92,15 +92,15 @@ func printTargetStatus(tagPrefix string, tagStatus []client.TagStatus) {
 			if tgt.Version > 0 {
 				details = fmt.Sprintf("`fioctl targets show %d`", tgt.Version)
 			}
-			t.AddLine(fmt.Sprintf("%-6d%-1s", tgt.Version, orphan), tgt.Devices, tgt.Reinstalling, details)
+			t.AddLine(fmt.Sprintf("%-6d%-1s", tgt.Version, orphan), tgt.Devices, details)
 		}
 		t.Print()
 		fmt.Println()
 
-		t = subcommands.Tabby(1, "DEVICE GROUP", "DEVICES", "ON LATEST", "ONLINE", "INSTALLING")
+		t = subcommands.Tabby(1, "DEVICE GROUP", "DEVICES", "ON LATEST", "ONLINE")
 		if len(tag.DeviceGroups) > 0 {
 			for _, g := range tag.DeviceGroups {
-				t.AddLine(g.Name, g.DevicesTotal, g.DevicesOnLatest, g.DevicesOnline, g.Reinstalling)
+				t.AddLine(g.Name, g.DevicesTotal, g.DevicesOnLatest, g.DevicesOnline)
 			}
 		}
 		t.Print()

--- a/subcommands/waves/status.go
+++ b/subcommands/waves/status.go
@@ -138,7 +138,7 @@ func doShowWaveStatus(cmd *cobra.Command, args []string) {
 
 func showGroupStatusTargets(group client.RolloutGroupStatus, status *client.WaveStatus) {
 	fmt.Printf("\n## Device Group: %s\n", group.Name)
-	t := subcommands.Tabby(1, "TARGET", "DEVICES", "INSTALLING", "DETAILS")
+	t := subcommands.Tabby(1, "TARGET", "DEVICES", "DETAILS")
 	for _, tgt := range group.Targets {
 		var mark, details string
 		if tgt.Version == status.Version {
@@ -149,7 +149,7 @@ func showGroupStatusTargets(group client.RolloutGroupStatus, status *client.Wave
 		if tgt.Version > 0 {
 			details = fmt.Sprintf("`fioctl targets show %d`", tgt.Version)
 		}
-		t.AddLine(fmt.Sprintf("%-6d%2s", tgt.Version, mark), tgt.Devices, tgt.Reinstalling, details)
+		t.AddLine(fmt.Sprintf("%-6d%2s", tgt.Version, mark), tgt.Devices, details)
 	}
 	t.Print()
 }


### PR DESCRIPTION
We are going to remove this field from our APIs.
It is causing us performance problems, while providing little value.