### PR TITLE
Finish cleanup of text

### DIFF
--- a/subcommands/secrets/cmd.go
+++ b/subcommands/secrets/cmd.go
@@ -11,7 +11,7 @@ var api *client.Api
 
 var cmd = &cobra.Command{
 	Use:   "secrets",
-	Short: "Manage secret credentials configured in a factory",
+	Short: "Manage secret credentials configured in a Factory",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		api = subcommands.Login(cmd)
 	},

--- a/subcommands/secrets/list.go
+++ b/subcommands/secrets/list.go
@@ -15,14 +15,14 @@ import (
 func init() {
 	cmd.AddCommand(&cobra.Command{
 		Use:   "list",
-		Short: "List secret credentials configured in the factory",
+		Short: "List secret credentials configured in the Factory",
 		Run:   doList,
 	})
 }
 
 func doList(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
-	logrus.Debugf("Listing factory secrets for: %s", factory)
+	logrus.Debugf("Listing Factory secrets for: %s", factory)
 
 	triggers, err := api.FactoryTriggers(factory)
 	subcommands.DieNotNil(err)

--- a/subcommands/secrets/update.go
+++ b/subcommands/secrets/update.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	cmd.AddCommand(&cobra.Command{
 		Use:   "update secret_name=secret_val...",
-		Short: "Update secret(s) in a factory",
+		Short: "Update secret(s) in a Factory",
 		Example: `
   # Create or update a secret
   fioctl secrets update githubtok=foo
@@ -33,7 +33,7 @@ func init() {
 
 func doUpdate(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
-	logrus.Debugf("Updating factory secrets for: %s", factory)
+	logrus.Debugf("Updating Factory secrets for: %s", factory)
 
 	triggers, err := api.FactoryTriggers(factory)
 	subcommands.DieNotNil(err)

--- a/subcommands/status/cmd.go
+++ b/subcommands/status/cmd.go
@@ -18,7 +18,7 @@ var inactiveThreshold int
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Get dashboard view of a factory and its devices",
+		Short: "Get dashboard view of a Factory and its devices",
 		Run:   showStatus,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			api = subcommands.Login(cmd)

--- a/subcommands/targets/add.go
+++ b/subcommands/targets/add.go
@@ -26,10 +26,10 @@ type Targets map[string]*client.Target
 func init() {
 	addCmd := &cobra.Command{
 		Use:   "add",
-		Short: "Compose and add Targets to Factory's  TUF targets metadata",
+		Short: "Compose and add Targets to Factory's TUF Targets metadata",
 		Run:   doAdd,
 		Long: `
-Compose new Targets out of the latest Targets tagged with the specified source tag and the specified via the command arguments either OSTree commit hashes or App URIs.
+Compose new Targets out of the latest ones with the specified source tag via the command arguments — either OSTree commit hashes or App URIs.
 
 fioctl targets add --type <ostree | app> --tags <comma,separate,list of Target tags> --src-tag <source Target tag> [--targets-creator <something about Targets originator>]\ 
 	<hardware ID> <ostree commit hash> [<hardware ID> <ostree commit hash>]  (for ostree type)
@@ -45,7 +45,7 @@ Add new App Targets:
 	cmd.AddCommand(addCmd)
 	addCmd.Flags().StringVarP(&addTargetType, "type", "", "", "Target type")
 	addCmd.Flags().StringVarP(&addTags, "tags", "", "", "comma,separate,list of Target tags")
-	addCmd.Flags().StringVarP(&addSrcTag, "src-tag", "", "", "OSTree Target tag to base app targets on")
+	addCmd.Flags().StringVarP(&addSrcTag, "src-tag", "", "", "OSTree Target tag to base app Targets on")
 	addCmd.Flags().BoolVarP(&addQuiet, "quiet", "", false, "don't print generated new Targets to stdout")
 	addCmd.Flags().BoolVarP(&addDryRun, "dry-run", "", false, "don't post generated new Targets")
 	addCmd.Flags().StringVarP(&addTargetsCreator, "targets-creator", "", "fioctl", "optional name/comment/context about Targets origination")
@@ -169,11 +169,11 @@ func deriveTargets(factory string, hwIds map[string]interface{}, srcTag string, 
 	// We assume that the initial OSTree Target(s) is/are created by the OTA service during Factory creation,
 	// hence we don't need to create a new Target from scratch in this command, just derive Targets from existing one.
 	if len(latestTargetsPerHwId) == 0 {
-		return nil, fmt.Errorf("no any source Targets to derive new Targets from are found; source tag: %s", srcTag)
+		return nil, fmt.Errorf("Could not find source Target to derive new Target from; source tag: %s", srcTag)
 	}
 	for id := range hwIds {
 		if _, ok := latestTargetsPerHwId[id]; !ok {
-			return nil, fmt.Errorf("no source Target to derive new Target from is found"+
+			return nil, fmt.Errorf("Could not find source Target to derive new Target from"+
 				" for the source tag `%s` and the hardware ID `%s`", srcTag, id)
 		}
 	}

--- a/subcommands/targets/artifacts.go
+++ b/subcommands/targets/artifacts.go
@@ -113,7 +113,7 @@ func doArtifacts(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
 
 	if len(args) == 0 {
-		logrus.Debugf("Showing all testing done for factory: %s", factory)
+		logrus.Debugf("Showing all testing done for Factory: %s", factory)
 		listAll(factory)
 		os.Exit(0)
 	}
@@ -123,7 +123,7 @@ func doArtifacts(cmd *cobra.Command, args []string) {
 		subcommands.DieNotNil(fmt.Errorf("Invalid Target number: %s", args[0]))
 	}
 	if len(args) == 1 {
-		logrus.Debugf("Showing target artifacts for %s %d", factory, target)
+		logrus.Debugf("Showing Target artifacts for %s %d", factory, target)
 		listArtifacts(factory, target)
 	} else {
 		artifact := args[1]

--- a/subcommands/targets/cmd.go
+++ b/subcommands/targets/cmd.go
@@ -11,7 +11,7 @@ var api *client.Api
 
 var cmd = &cobra.Command{
 	Use:   "targets",
-	Short: "Manage factory's TUF targets",
+	Short: "Manage Factory TUF targets",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		api = subcommands.Login(cmd)
 	},

--- a/subcommands/targets/deltas.go
+++ b/subcommands/targets/deltas.go
@@ -21,14 +21,14 @@ var (
 func init() {
 	var deltas = &cobra.Command{
 		Use:   "static-deltas <target-version> [<from-version>...]",
-		Short: "Generate static deltas to the given target version to make OTAs faster",
+		Short: "Generate static deltas to the given Target version to make OTAs faster",
 		Run:   doDeltas,
 		Args:  cobra.MinimumNArgs(1),
-		Long: `In many cases OTA updates will have many OSTree changes. These updates
-can be downloaded significantly faster by generating OSTree static
-deltas. Static deltas are generated with a "from(sha) -> to(sha)" type
-logic. This command takes the given Target version and will produce a
-number of static deltas to ensure devices will be updated efficiently.`,
+		Long: `In many cases OTA updates will have multiple OSTree changes. These updates
+can be downloaded faster by generating OSTree static
+deltas. Static deltas are generated using "from(sha) -> to(sha)" type
+logic. This command takes the given Target version, and produces a
+number of static deltas to ensure devices are updated efficiently.`,
 		Example: `
   # There are two ways to run this command:
 
@@ -43,7 +43,7 @@ number of static deltas to ensure devices will be updated efficiently.`,
 	deltas.Flags().StringVarP(&byTag, "by-tag", "", "", "Find from-versions devices on the given tag")
 	deltas.Flags().BoolVarP(&noTail, "no-tail", "", false, "Don't tail output of CI Job")
 	deltas.Flags().BoolVarP(&dryRun, "dryrun", "", false, "Only show what deltas would be produced")
-	deltas.Flags().StringVarP(&hwId, "hw-id", "", "", "Filter from and to targets by the given hardware ID")
+	deltas.Flags().StringVarP(&hwId, "hw-id", "", "", "Filter from and to Targets by the given hardware ID")
 }
 
 func findVersions(maxVer int, forTag string, tags []client.TagStatus) (bool, []int) {
@@ -97,13 +97,13 @@ func doDeltas(cmd *cobra.Command, args []string) {
 		}
 	}
 	if len(froms) == 0 {
-		subcommands.DieNotNil(errors.New("No targets found to generate deltas for."))
+		subcommands.DieNotNil(errors.New("No Targets found to generate deltas for."))
 	}
 	if dryRun {
 		if len(hwId) > 0 {
-			fmt.Printf("Dry run: Would be generated static deltas for targets with hardware ID %s and versions:\n", hwId)
+			fmt.Printf("Dry run: Would generate static deltas for Targets with hardware ID %s and versions:\n", hwId)
 		} else {
-			fmt.Println("Dry run: Would be generated static deltas for target versions:")
+			fmt.Println("Dry run: Would generate static deltas for Target versions:")
 		}
 		for _, v := range froms {
 			fmt.Println("  ", v, "->", toVer)

--- a/subcommands/targets/edit.go
+++ b/subcommands/targets/edit.go
@@ -30,7 +30,7 @@ func init() {
 
 func doEdit(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
-	logrus.Debugf("Editing targets for %s", factory)
+	logrus.Debugf("Editing Targets for %s", factory)
 
 	// Get raw json
 	targets, err := api.TargetsList(factory)
@@ -83,7 +83,7 @@ func doEdit(cmd *cobra.Command, args []string) {
 	var newTargets tuf.Files
 	err = json.Unmarshal(content, &newTargets)
 	if err != nil {
-		fmt.Println("Unable to parse new targets: ", err)
+		fmt.Println("Unable to parse new Targets: ", err)
 		os.Exit(1)
 	}
 	type TargetsUp struct {
@@ -92,7 +92,7 @@ func doEdit(cmd *cobra.Command, args []string) {
 	upload := TargetsUp{newTargets}
 	content, err = json.Marshal(upload)
 	if err != nil {
-		fmt.Println("Unable to marshall targets data: ", err)
+		fmt.Println("Unable to marshal Targets data: ", err)
 		os.Exit(1)
 	}
 

--- a/subcommands/targets/image.go
+++ b/subcommands/targets/image.go
@@ -30,7 +30,7 @@ func init() {
 	}
 	cmd.AddCommand(imageCmd)
 	imageCmd.Flags().StringVarP(&appsShortlist, "apps", "", "",
-		"comma,separate,list of Target apps to preload into a resultant image."+
+		"comma,separate,list of Target apps to preload into an image."+
 			" All apps of Target are preloaded if the flag is not defined or empty")
 	imageCmd.Flags().BoolVarP(&noTail, "no-tail", "", false, "Don't tail output of CI Job")
 	imageCmd.Flags().StringVarP(&ciScriptsRepo, "ci-scripts-repo", "", "https://github.com/foundriesio/ci-scripts", "Override to custom version of ci-scripts")

--- a/subcommands/targets/list.go
+++ b/subcommands/targets/list.go
@@ -87,13 +87,13 @@ func init() {
 	cmd.AddCommand(listCmd)
 	listCmd.Flags().BoolVarP(&listRaw, "raw", "r", false, "Print raw targets.json")
 	listCmd.Flags().BoolVarP(&listProd, "production", "", false, "Show the production version targets.json")
-	listCmd.Flags().StringVarP(&listByTag, "by-tag", "", "", "Only list targets that match the given tag")
+	listCmd.Flags().StringVarP(&listByTag, "by-tag", "", "", "Only list Targets that match the given tag")
 	listCmd.Flags().StringSliceVarP(&showColumns, "columns", "", defCols, "Specify which columns to display")
 }
 
 func doList(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
-	logrus.Debugf("Listing targets for %s tag(%s)", factory, listByTag)
+	logrus.Debugf("Listing Targets for %s tag(%s)", factory, listByTag)
 
 	if listProd && len(listByTag) == 0 {
 		subcommands.DieNotNil(errors.New("--production flag requires --by-tag flag"))

--- a/subcommands/targets/offline-update.go
+++ b/subcommands/targets/offline-update.go
@@ -61,13 +61,13 @@ func init() {
 		Run:   doOfflineUpdate,
 		Args:  cobra.ExactArgs(2),
 		Example: `
-	# Download update content of the wave target #1451 for "intel-corei7-64" hardware type
+	# Download update content of the Wave Target #1451 for "intel-corei7-64" hardware type
 	fioctl targets offline-update intel-corei7-64-lmp-1451 /mnt/flash-drive/offline-update-content --wave wave-deployment-001
 
-	# Download update content of the production target #1451 tagged by "release-01" for "intel-corei7-64" hardware type
+	# Download update content of the production Target #1451 tagged by "release-01" for "intel-corei7-64" hardware type
 	fioctl targets offline-update intel-corei7-64-lmp-1451 /mnt/flash-drive/offline-update-content --tag release-01 --prod
 
-	# Download update content of the CI target #1451 tagged by "devel" for "raspberrypi4-64" hardware type
+	# Download update content of the CI Target #1451 tagged by "devel" for "raspberrypi4-64" hardware type
 	fioctl targets offline-update raspberrypi4-64-lmp-1448 /mnt/flash-drive/offline-update-content --tag devel --expires-in-days 15
 
 	`,
@@ -78,7 +78,7 @@ func init() {
 	offlineUpdateCmd.Flags().BoolVarP(&ouProd, "prod", "", false,
 		"Instruct to fetch content of production Target")
 	offlineUpdateCmd.Flags().StringVarP(&ouWave, "wave", "", "",
-		"Instruct to fetch content of wave Target; a wave name should be specified")
+		"Instruct to fetch content of Wave Target; a wave name should be specified")
 	offlineUpdateCmd.Flags().IntVarP(&ouExpiresIn, "expires-in-days", "e", 30,
 		"Desired metadata validity period in days")
 	offlineUpdateCmd.Flags().BoolVarP(&ouTufOnly, "tuf-only", "m", false,
@@ -86,7 +86,7 @@ func init() {
 	offlineUpdateCmd.Flags().BoolVarP(&ouNoApps, "no-apps", "", false,
 		"Skip fetching Target Apps")
 	offlineUpdateCmd.Flags().BoolVarP(&ouAllowMultipleTargets, "allow-multiple-targets", "", false,
-		"Allow multiple targets to be stored in the same <dst> directory")
+		"Allow multiple Targets to be stored in the same <dst> directory")
 	offlineUpdateCmd.MarkFlagsMutuallyExclusive("tag", "wave")
 	offlineUpdateCmd.MarkFlagsMutuallyExclusive("prod", "wave")
 	initSignCmd(offlineUpdateCmd)
@@ -96,11 +96,11 @@ func init() {
 func initSignCmd(parentCmd *cobra.Command) {
 	signCmd := &cobra.Command{
 		Use:   "sign <path to an offline bundle>",
-		Short: "Sign an offline bundle with a targets role offline key",
-		Long: `Sign an offline bundle with a targets role offline key.
+		Short: "Sign an offline bundle with a Targets role offline key",
+		Long: `Sign an offline bundle with a Targets role offline key.
 
-Run this command if your offline update bundle contains production/wave targets.
-In this case, the bundle has to be signed by one or more targets role offline keys.
+Run this command if your offline update bundle contains production/Wave targets.
+In this case, the bundle has to be signed by one or more Targets role offline key.
 The number of required signatures depends on the threshold number set in the current TUF root role metadata,
 and is printed by this command.`,
 		Run:  doSignBundle,
@@ -108,7 +108,7 @@ and is printed by this command.`,
 	}
 	signCmd.Flags().StringP("keys", "k", "",
 		"Path to the <tuf-targets-keys.tgz> key to sign the bundle metadata with. "+
-			"This is the same key used to sign prod & wave TUF targets.")
+			"This is the same key used to sign prod & Wave TUF Targets.")
 	_ = signCmd.MarkFlagRequired("keys")
 	parentCmd.AddCommand(signCmd)
 }
@@ -120,7 +120,7 @@ func initShowCmd(parentCmd *cobra.Command) {
 		Long: `Parse and print the specified bundle metadata.
 
 Run this command if you would like to get information about an offline bundle.
-Specifically, what targets it includes, what the type of the targets (CI or production),
+Specifically, what Targets it includes, what the type of the Targets (CI or production),
 a bundle's expiration time', etc.`,
 		Run:  doShowBundle,
 		Args: cobra.ExactArgs(1),
@@ -160,8 +160,8 @@ func doOfflineUpdate(cmd *cobra.Command, args []string) {
 		if !isDstDirClean(dstDir) {
 			if !ouAllowMultipleTargets {
 				subcommands.DieNotNil(errors.New(`Destination directory already has update data.
-Provide a clean destination directory or re-run with --allow-multiple-targets to add a new target to a directory which already has update data.
-Notice that multiple targets in the same directory is only supported in LmP >= v92.`))
+Provide a clean destination directory or re-run with --allow-multiple-targets to add a new Target to a directory which already has update data.
+Notice that multiple Targets in the same directory is only supported in LmP >= v92.`))
 			}
 		}
 
@@ -191,8 +191,8 @@ Notice that multiple targets in the same directory is only supported in LmP >= v
 					fmt.Printf("Downloading Apps fetched by the `publish-compose-apps` run; apps: %s, uri: %s...\n", ti.fetchedApps.Shortlist, ti.fetchedApps.Uri)
 					err = downloadAppsArchive(ti.fetchedApps.Uri, path.Join(dstDir, "apps"))
 				} else {
-					fmt.Println("No apps found to fetch for an offline update to a given target. " +
-						"The bundle will update only rootfs/ostree. Check your factory configuration if this is not your intention.")
+					fmt.Println("No apps found to fetch for an offline update to a given Target. " +
+						"The bundle will only update rootfs/ostree. Check your Factory configuration if this is not your intention.")
 				}
 			}
 			if herr := client.AsHttpError(err); herr != nil && herr.Response.StatusCode == 404 {
@@ -253,7 +253,7 @@ func getWaveTargetMeta(factory string, targetName string, wave string) (*tuf.Fil
 	if foundTargetMeta, ok := waveTargets[wave].Signed.Targets[targetName]; ok {
 		return &foundTargetMeta, nil
 	} else {
-		return nil, fmt.Errorf("The specified Target is not found among wave targets;"+
+		return nil, fmt.Errorf("The specified Target is not found among Wave Targets;"+
 			" target: %s, wave: %s", targetName, wave)
 	}
 }
@@ -262,14 +262,14 @@ func getProdTargetMeta(factory string, targetName string, tag string) (*tuf.File
 	targets, err := api.ProdTargetsGet(factory, tag, true)
 	if err != nil {
 		if herr := client.AsHttpError(err); herr != nil && herr.Response.StatusCode == 404 {
-			return nil, fmt.Errorf("No production targets were found for the specified tag `%s`", tag)
+			return nil, fmt.Errorf("No production Targets were found for the specified tag `%s`", tag)
 		}
 		return nil, fmt.Errorf("Failed to get production Target metadata: %s", err.Error())
 	}
 	if foundTargetMeta, ok := targets.Signed.Targets[targetName]; ok {
 		return &foundTargetMeta, nil
 	} else {
-		return nil, fmt.Errorf("No production target with the given tag is found;"+
+		return nil, fmt.Errorf("No production Target with the given tag found;"+
 			" target: %s, tag: %s", targetName, tag)
 	}
 }
@@ -278,7 +278,7 @@ func getCiTargetMeta(factory string, targetName string, tag string) (*tuf.FileMe
 	data, err := api.TufMetadataGet(factory, "targets.json", tag, false)
 	if err != nil {
 		if herr := client.AsHttpError(err); herr != nil && herr.Response.StatusCode == 404 {
-			return nil, fmt.Errorf("No CI targets were found for the specified tag `%s`", tag)
+			return nil, fmt.Errorf("No CI Targets found for the specified tag `%s`", tag)
 		}
 		return nil, fmt.Errorf("Failed to get CI Target metadata: %s", err.Error())
 	}
@@ -290,7 +290,7 @@ func getCiTargetMeta(factory string, targetName string, tag string) (*tuf.FileMe
 	if foundTargetMeta, ok := targets.Signed.Targets[targetName]; ok {
 		return &foundTargetMeta, nil
 	} else {
-		return nil, fmt.Errorf("No CI target with the given tag is found;"+
+		return nil, fmt.Errorf("No CI Target with the given tag found;"+
 			" target: %s, tag: %s", targetName, tag)
 	}
 }
@@ -541,7 +541,7 @@ func signBundleTargets(rootMeta *client.AtsTufRoot, bundleTargetsMeta *tuf.Signe
 	if bundleTargetsMeta.Signed == nil {
 		panic(fmt.Errorf("the input bundle metadata to sign is nil"))
 	}
-	fmt.Printf("Signing the bundle with a new key; ID: %s, type: %s\n", signer.Id, signer.Type.Name())
+	fmt.Printf("Signing the bundle with new key; ID: %s, type: %s\n", signer.Id, signer.Type.Name())
 	signatures, err := keys.SignTufMeta(*bundleTargetsMeta.Signed, signer)
 	if err != nil {
 		return err
@@ -556,7 +556,7 @@ func doShowBundle(cmd *cobra.Command, args []string) {
 	subcommands.DieNotNil(err)
 	bundleMeta := ouBundleTufMeta{}
 	subcommands.DieNotNil(json.Unmarshal(*bundleTufMeta.Signed, &bundleMeta))
-	fmt.Println("Bundle targets info:")
+	fmt.Println("Bundle Targets info:")
 	fmt.Printf("\tType:\t\t%s\n", bundleMeta.ouBundleMeta.Type)
 	fmt.Printf("\tTag:\t\t%s\n", bundleMeta.Tag)
 	fmt.Printf("\tExpires:\t%s\n", bundleMeta.SignedCommon.Expires)

--- a/subcommands/targets/prune.go
+++ b/subcommands/targets/prune.go
@@ -23,28 +23,28 @@ var (
 func init() {
 	pruneCmd := &cobra.Command{
 		Use:   "prune <target> [<target>...]",
-		Short: "Prune target(s)",
+		Short: "Prune Target(s)",
 		Run:   doPrune,
 		Args:  cobra.MinimumNArgs(1),
 		Example: `
-  # prune a single target by name:
+  # prune a single Target by name:
   fioctl targets prune intel-corei7-64-lmp-123
 
-  # prune all targets with the "custom.tags" set to ["devel"]:
+  # prune all Targets with the "custom.tags" set to ["devel"]:
   fioctl targets prune --by-tag devel
 
-  # prune all targets with the "custom.tags" set to ["devel"] except for the most recent 10:
+  # prune all Targets with the "custom.tags" set to ["devel"] except for the most recent 10:
   fioctl targets prune --by-tag devel --keep-last=10
 
-  # prune all targets with the "custom.tags" set to ["devel", "my-test"]:
+  # prune all Targets with the "custom.tags" set to ["devel", "my-test"]:
   fioctl targets prune --by-tag devel my-test
 
-  # see the list of targets to be pruned (based on the above example), don't prune them:
+  # see the list of Targets to be pruned (based on the above example), but don't prune them:
   fioctl targets prune --by-tag devel my-test --dryrun`,
 	}
 	cmd.AddCommand(pruneCmd)
 	pruneCmd.Flags().BoolVarP(&pruneNoTail, "no-tail", "", false, "Don't tail output of CI Job")
-	pruneCmd.Flags().BoolVarP(&pruneByTag, "by-tag", "", false, "Prune all targets by tags instead of name")
+	pruneCmd.Flags().BoolVarP(&pruneByTag, "by-tag", "", false, "Prune all Targets by tags instead of name")
 	pruneCmd.Flags().IntVarP(&pruneKeepLast, "keep-last", "", 0, "Keep the last X number of builds for a tag when pruning")
 	pruneCmd.Flags().BoolVarP(&pruneDryRun, "dryrun", "", false, "Only show what would be pruned")
 }
@@ -98,7 +98,7 @@ func doPrune(cmd *cobra.Command, args []string) {
 			for _, name := range target_names {
 				parts := strings.SplitN(name, "lmp-", 2)
 				if len(parts) != 2 {
-					fmt.Printf("Unable to decode target name: %s\n", name)
+					fmt.Printf("Unable to decode Target name: %s\n", name)
 					os.Exit(1)
 				}
 				custom, _ := api.TargetCustom(targets[name])
@@ -139,7 +139,7 @@ func doPrune(cmd *cobra.Command, args []string) {
 		target_names = args
 	}
 
-	fmt.Printf("Deleting targets:\n %s\n", strings.Join(target_names, "\n "))
+	fmt.Printf("Deleting Targets:\n %s\n", strings.Join(target_names, "\n "))
 	if pruneDryRun {
 		fmt.Println("Dry run, exiting")
 		return

--- a/subcommands/targets/show.go
+++ b/subcommands/targets/show.go
@@ -28,18 +28,18 @@ var sbomFormats formats
 func init() {
 	showCmd := &cobra.Command{
 		Use:   "show <version>",
-		Short: "Show details of a specific target.",
+		Short: "Show details of a specific Target.",
 		Run:   doShow,
 		Args:  cobra.ExactArgs(1),
 		Example: `
   # Show details of all Targets with version 42:
   fioctl targets show 42
 
-  # Show a specific Target by name:
+  # Show specific Target by name:
   fioctl targets show intel-corei7-64-lmp-42`,
 	}
 	cmd.AddCommand(showCmd)
-	showCmd.PersistentFlags().String("production-tag", "", "Look up target from the production tag")
+	showCmd.PersistentFlags().String("production-tag", "", "Look up Target from the production tag")
 
 	showAppCmd := &cobra.Command{
 		Use:   "compose-app <version> <app>",
@@ -59,7 +59,7 @@ func init() {
   # Show all SBOM files for Target version 42:
   fioctl targets show sboms 42
 
-  # Show a subset of the SBOMS for this target. In this case, the 32-bit Arm
+  # Show a subset of the SBOMS for the Target. In this case, the 32-bit Arm
   # container SBOMS:
   fioctl targets show sboms 42 41/build-armhf
  
@@ -69,7 +69,7 @@ func init() {
   # Show overview of a specific SBOM as CSV:
   fioctl targets show sboms --format csv 42 41/build-armhf alpine:latest/arm.spdx.json
   
-  # Download all SBOMS for a target to /tmp:
+  # Download all SBOMS for a Target to /tmp:
   fioctl targets show sboms 42 --download /tmp
   
   # Download a filtered list of SBOMs to /tmp:
@@ -78,7 +78,7 @@ func init() {
   # Download a specific SBOM as cyclonedx:
   fioctl targets show sboms 42 41/build-armhf --download /tmp --format cyclonedx
 
-  # Download all SBOMS for a target to /tmp as CSV:
+  # Download all SBOMS for a Target to /tmp as CSV:
   fioctl targets show sboms 42 --download /tmp --format csv`,
 	}
 
@@ -106,7 +106,7 @@ func sortedAppsNames(target client.TufCustom) []string {
 func doShow(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
 	version := args[0]
-	logrus.Debugf("Showing targets for %s %s", factory, version)
+	logrus.Debugf("Showing Targets for %s %s", factory, version)
 
 	prodTag, _ := cmd.Flags().GetString("production-tag")
 
@@ -156,7 +156,7 @@ func doShowComposeApp(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
 	version := args[0]
 	appName := args[1]
-	logrus.Debugf("Showing target for %s %s %s", factory, version, appName)
+	logrus.Debugf("Showing Target for %s %s %s", factory, version, appName)
 
 	prodTag, _ := cmd.Flags().GetString("production-tag")
 
@@ -164,7 +164,7 @@ func doShowComposeApp(cmd *cobra.Command, args []string) {
 	for name, custom := range targets {
 		_, ok := custom.ComposeApps[appName]
 		if !ok {
-			fmt.Println("ERROR: App not found in target")
+			fmt.Println("ERROR: App not found in Target")
 			os.Exit(1)
 		}
 		appInfo, err := api.TargetComposeApp(factory, name, appName)
@@ -236,11 +236,11 @@ func getTargets(factory string, prodTag string, version string) ([]string, map[s
 		}
 	} else if !byName {
 		var err error
-		logrus.Debug("Looking up targets by version")
+		logrus.Debug("Looking up Targets by version")
 		targets, err = api.TargetsList(factory, version)
 		subcommands.DieNotNil(err)
 	} else {
-		logrus.Debug("Looking up target by name")
+		logrus.Debug("Looking up Target by name")
 		target, err := api.TargetGet(factory, version)
 		subcommands.DieNotNil(err)
 		targets = make(tuf.Files)
@@ -257,7 +257,7 @@ func getTargets(factory string, prodTag string, version string) ([]string, map[s
 			continue
 		}
 		if custom.TargetFormat != "OSTREE" {
-			logrus.Debugf("Skipping non-ostree target: %v", target)
+			logrus.Debugf("Skipping non-ostree Target: %v", target)
 			continue
 		}
 		matches[name] = *custom
@@ -265,7 +265,7 @@ func getTargets(factory string, prodTag string, version string) ([]string, map[s
 		names = append(names, name)
 	}
 	if len(matches) == 0 {
-		fmt.Println("ERROR: no target found for this version")
+		fmt.Println("ERROR: no Target found for version")
 		os.Exit(1)
 	}
 	sort.Strings(names)
@@ -334,7 +334,7 @@ func getSbomTargetName(factory, prodTag, version string) string {
 	for name := range targets {
 		return name
 	}
-	subcommands.DieNotNil(fmt.Errorf("Unable to find target for version: %s", version))
+	subcommands.DieNotNil(fmt.Errorf("Unable to find Target for version: %s", version))
 	return "" // Make compiler happy
 }
 

--- a/subcommands/targets/tag.go
+++ b/subcommands/targets/tag.go
@@ -22,10 +22,10 @@ var (
 func init() {
 	var tagCmd = &cobra.Command{
 		Use:   "tag <target> [<target>...]",
-		Short: "Apply a comma separated list of tags to one or more targets.",
+		Short: "Apply a comma separated list of tags to one or more Targets.",
 		Example: `
-  # Promote Target #42 currently tagged as master
-  fioctl targets tag --tags master,promoted --by-version 42
+  # Promote Target #42 currently tagged as main
+  fioctl targets tag --tags main,promoted --by-version 42
 
   # Tag a specific Target by name
   fioctl targets tag --tags master,testing intel-corei7-64-lmp-42`,
@@ -36,7 +36,7 @@ func init() {
 	tagCmd.Flags().StringVarP(&tagTags, "tags", "T", "", "comma,separate,list")
 	tagCmd.Flags().BoolVarP(&tagAppend, "append", "", false, "Append the given tags rather than set them")
 	tagCmd.Flags().BoolVarP(&tagNoTail, "no-tail", "", false, "Don't tail output of CI Job")
-	tagCmd.Flags().BoolVarP(&tagByVersion, "by-version", "", false, "Apply tags to all targets matching the given version(s)")
+	tagCmd.Flags().BoolVarP(&tagByVersion, "by-version", "", false, "Apply tags to all Targets matching the given version(s)")
 	tagCmd.Flags().BoolVarP(&dryRun, "dryrun", "", false, "Just show the changes that would be applied")
 }
 
@@ -87,7 +87,7 @@ func doTag(cmd *cobra.Command, args []string) {
 			}
 		}
 		if len(updates) == 0 {
-			fmt.Println("ERROR: no targets found matching the given versions")
+			fmt.Println("ERROR: no Targets found matching the given versions")
 			os.Exit(1)
 		}
 	} else {

--- a/subcommands/targets/tests.go
+++ b/subcommands/targets/tests.go
@@ -18,11 +18,11 @@ import (
 func init() {
 	cmd.AddCommand(&cobra.Command{
 		Use:   "tests [<target> [<test-id> [<artifact name>]]]",
-		Short: "Show testing done against a target",
+		Short: "Show testing done against a Target",
 		Run:   doShowTests,
 		Args:  cobra.RangeArgs(0, 3),
 		Example: `
-  # List all testing performed in factory
+  # List all testing performed in the Factory
   fioctl targets tests
 
   # Show tests run against Target 12
@@ -122,7 +122,7 @@ func doShowTests(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
 
 	if len(args) == 0 {
-		logrus.Debugf("Showing all testing done for factory: %s", factory)
+		logrus.Debugf("Showing all testing done for Factory: %s", factory)
 		listAll(factory)
 		os.Exit(0)
 	}
@@ -130,16 +130,16 @@ func doShowTests(cmd *cobra.Command, args []string) {
 	target, err := strconv.Atoi(args[0])
 	subcommands.DieNotNil(err)
 	if len(args) == 1 {
-		logrus.Debugf("Showing target testing for %s %d", factory, target)
+		logrus.Debugf("Showing Target testing for %s %d", factory, target)
 		list(factory, target)
 	} else if len(args) == 2 {
 		testId := args[1]
-		logrus.Debugf("Showing target test results for %s %d - %s", factory, target, testId)
+		logrus.Debugf("Showing Target test results for %s %d - %s", factory, target, testId)
 		show(factory, target, testId)
 	} else {
 		testId := args[1]
 		artifact := args[2]
-		logrus.Debugf("Showing target test artifacts for %s %d - %s / %s", factory, target, testId, artifact)
+		logrus.Debugf("Showing Target test artifacts for %s %d - %s / %s", factory, target, testId, artifact)
 		content, err := api.TargetTestArtifact(factory, target, testId, artifact)
 		subcommands.DieNotNil(err)
 		os.Stdout.Write(*content)

--- a/subcommands/teams/cmd.go
+++ b/subcommands/teams/cmd.go
@@ -13,7 +13,7 @@ import (
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "teams [<team_name>]",
-		Short: "List teams belonging to a FoundriesFactory",
+		Short: "List teams belonging to a Factory",
 		Args:  cobra.RangeArgs(0, 1),
 		Run:   doTeamsCommand,
 	}
@@ -31,7 +31,7 @@ func doTeamsCommand(cmd *cobra.Command, args []string) {
 }
 
 func doList(api *client.Api, factory string) {
-	logrus.Debugf("Listing FoundriesFactory teams for %s", factory)
+	logrus.Debugf("Listing teams for %s", factory)
 
 	teams, err := api.TeamsList(factory)
 	subcommands.DieNotNil(err)

--- a/subcommands/users/cmd.go
+++ b/subcommands/users/cmd.go
@@ -14,7 +14,7 @@ import (
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "users [<user_id>]",
-		Short: "List users with access to a FoundriesFactory",
+		Short: "List users with access to a Factory",
 		Args:  cobra.RangeArgs(0, 1),
 		Run:   doUserCommand,
 	}
@@ -32,7 +32,7 @@ func doUserCommand(cmd *cobra.Command, args []string) {
 }
 
 func doList(api *client.Api, factory string) {
-	logrus.Debugf("Listing factory users for %s", factory)
+	logrus.Debugf("Listing users for %s", factory)
 
 	users, err := api.UsersList(factory)
 	subcommands.DieNotNil(err)

--- a/subcommands/version/cmd.go
+++ b/subcommands/version/cmd.go
@@ -18,7 +18,7 @@ func NewCommand() *cobra.Command {
 		Short: "Show version information of this tool.",
 		Run:   doVersion,
 	}
-	cmd.Flags().StringVarP(&updateTo, "update-to", "", "", "Update to the given version of fioctl")
+	cmd.Flags().StringVarP(&updateTo, "update-to", "", "", "Update to the given version of Fioctl")
 	return cmd
 }
 
@@ -38,7 +38,7 @@ func doVersion(cmd *cobra.Command, args []string) {
 		}
 		if err := update.Do(); err != nil {
 			if os.IsPermission(err) {
-				DieNotNil(fmt.Errorf("there was a permission error while updating fioctl: %w. Please run again as an admin or root.", err))
+				DieNotNil(fmt.Errorf("There was a permission error while updating Fioctl: %w. Please run again as an admin or root.", err))
 			} else {
 				DieNotNil(err)
 			}
@@ -55,7 +55,7 @@ func doVersion(cmd *cobra.Command, args []string) {
 		fmt.Println("You can update by running:")
 		fmt.Println("\t", exe, "version", "--update-to", update.Version)
 	} else {
-		fmt.Println("This is the latest version of the tool.")
+		fmt.Println("This is the latest version.")
 	}
 }
 

--- a/subcommands/version/update_self_windows.go
+++ b/subcommands/version/update_self_windows.go
@@ -27,7 +27,7 @@ func replaceSelf(curExe, newExe string) error {
 		return err
 	}
 	if err := os.Rename(newExe, curExe); err != nil {
-		msg := "unable to update to the new fioctl binary. "
+		msg := "Unable to update to the new Fioctl binary. "
 		msg += "The old version is located at %s. "
 		msg += "The new version is located at %s. %w"
 		return fmt.Errorf(msg, oldExe, newExe, err)
@@ -43,7 +43,7 @@ func replaceSelf(curExe, newExe string) error {
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
 	}
 	if err := cmd.Start(); err != nil {
-		msg := "the new version of fioctl is ready to use. "
+		msg := "the new version of Fioctl is ready to use. "
 		msg += "However, there was a failure removing the old version: %w"
 		return fmt.Errorf(msg, err)
 	}

--- a/subcommands/version/updates.go
+++ b/subcommands/version/updates.go
@@ -77,7 +77,7 @@ func (f *FioctlUpdateFinder) FindLatest() (*FioctlUpdate, error) {
 			return nil, fmt.Errorf("unable to parse TUF data for %s: %s", name, err)
 		}
 		if target.Length == 0 {
-			return nil, fmt.Errorf("target %s has invalid length: %d", name, target.Length)
+			return nil, fmt.Errorf("Target %s has invalid length: %d", name, target.Length)
 		}
 		if custom.Platform == f.platform {
 			v, err := version.NewVersion(custom.Version)
@@ -134,7 +134,7 @@ func (u FioctlUpdate) Do() error {
 		return err
 	}
 	if res.StatusCode == 200 && res.ContentLength != u.len {
-		return fmt.Errorf("target size mismatch: %d != %d", res.ContentLength, u.len)
+		return fmt.Errorf("Target size mismatch: %d != %d", res.ContentLength, u.len)
 	}
 	defer res.Body.Close()
 	reader := io.LimitReader(res.Body, u.len)

--- a/subcommands/waves/cancel.go
+++ b/subcommands/waves/cancel.go
@@ -11,11 +11,10 @@ import (
 func init() {
 	cmd.AddCommand(&cobra.Command{
 		Use:   "cancel <wave>",
-		Short: "Cancel a given wave by name",
-		Long: `Cancel a given wave by name.
-Once canceled a wave is no longer available as an update source for production devices.
-However, those devices that has already updated to a wave version
-will remain on that version until a new version is rolled out.`,
+		Short: "Cancel a given Wave by name",
+		Long: `Cancel a given Wave by name.
+Once canceled, a Wave is no longer available as an update source for production devices.
+However, those already updated will remain on that version until a new version is rolled out.`,
 		Run:  doCancelWave,
 		Args: cobra.ExactArgs(1),
 	})
@@ -24,7 +23,7 @@ will remain on that version until a new version is rolled out.`,
 func doCancelWave(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
 	name := args[0]
-	logrus.Debugf("Canceling a wave %s for %s", name, factory)
+	logrus.Debugf("Canceling a Wave %s for %s", name, factory)
 
 	subcommands.DieNotNil(api.FactoryCancelWave(factory, name))
 }

--- a/subcommands/waves/cmd.go
+++ b/subcommands/waves/cmd.go
@@ -12,7 +12,7 @@ var api *client.Api
 var cmd = &cobra.Command{
 	Use:     "waves",
 	Aliases: []string{"wave"},
-	Short:   "Manage factory's waves",
+	Short:   "Manage Factory Waves",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		api = subcommands.Login(cmd)
 	},

--- a/subcommands/waves/complete.go
+++ b/subcommands/waves/complete.go
@@ -11,10 +11,10 @@ import (
 func init() {
 	cmd.AddCommand(&cobra.Command{
 		Use:   "complete <wave>",
-		Short: "Complete a given wave by name to make it generally available",
-		Long: `Complete a given wave by name.
-Once complete a wave becomes generally available as an update source for all production devices.
-A subsequent wave might become a new source for a part of production devices again.`,
+		Short: "Complete a given Wave by name to make it generally available",
+		Long: `Complete a given Wave by name.
+Once complete, a Wave generally becomes available as an update source for all production devices.
+A subsequent Wave might become a new source for a part of production devices again.`,
 		Run:  doCompleteWave,
 		Args: cobra.ExactArgs(1),
 	})
@@ -23,7 +23,7 @@ A subsequent wave might become a new source for a part of production devices aga
 func doCompleteWave(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
 	name := args[0]
-	logrus.Debugf("Completing a wave %s for %s", name, factory)
+	logrus.Debugf("Completing a Wave %s for %s", name, factory)
 
 	subcommands.DieNotNil(api.FactoryCompleteWave(factory, name))
 }

--- a/subcommands/waves/list.go
+++ b/subcommands/waves/list.go
@@ -17,9 +17,9 @@ func init() {
 	}
 	cmd.AddCommand(listCmd)
 	listCmd.Flags().Uint64P("limit", "n", 20, "Limit the number of results displayed.")
-	listCmd.Flags().Uint64P("page", "p", 1, "Page of waves to display when pagination is needed")
-	listCmd.Flags().StringP("status", "S", "", "Only show waves with a given status; one of (active, complete, canceled)")
-	listCmd.Flags().StringP("tag", "T", "", "Only show waves with a given tag")
+	listCmd.Flags().Uint64P("page", "p", 1, "Page of Waves to display when pagination is needed")
+	listCmd.Flags().StringP("status", "S", "", "Only show Waves with a given status; one of (active, complete, canceled)")
+	listCmd.Flags().StringP("tag", "T", "", "Only show Waves with a given tag")
 }
 
 func doListWaves(cmd *cobra.Command, args []string) {
@@ -28,7 +28,7 @@ func doListWaves(cmd *cobra.Command, args []string) {
 	showPage, _ := cmd.Flags().GetUint64("page")
 	status, _ := cmd.Flags().GetString("status")
 	tag, _ := cmd.Flags().GetString("tag")
-	logrus.Debugf("Showing a list of waves for %s", factory)
+	logrus.Debugf("Showing a list of Waves for %s", factory)
 
 	lst, err := api.FactoryListWaves(factory, limit, showPage, status, tag)
 	subcommands.DieNotNil(err)

--- a/subcommands/waves/rollout.go
+++ b/subcommands/waves/rollout.go
@@ -19,41 +19,41 @@ import (
 func init() {
 	rollout := &cobra.Command{
 		Use:   "rollout <wave>",
-		Short: "Roll out a wave to a subset of production devices",
-		Long: `Roll out a wave to a subset of production devices matching a wave's tag.
-Upon rollout a wave becomes available as an update source for a given subset of production devices.
-A rollout is not instant, rather each device will update to the wave's targets at some point.
+		Short: "Roll out a Wave to a subset of production devices",
+		Long: `Roll out a Wave to a subset of production devices matching a Wave's tag.
+Upon rollout, a Wave becomes available as an update source for a given subset of production devices.
+A rollout is not instant, rather each device will update to the Wave's Targets at some point.
 The exact update time is determined by many factors:
-device up and down lifecycle, its update schedule, networking between a device and update servers, etc.
+device up and down lifecycle, update schedule, networking between a device and update servers, etc.
 At least one command flag is required to limit the subset of devices to roll out to.
-If you want to roll out to all matching devices in a factory, please, use the "complete" command.`,
+If you want to roll out to all matching devices in a Factory, please, use the "complete" command.`,
 		Run:  doRolloutWave,
 		Args: cobra.RangeArgs(1, 2),
 		Example: `
-Rollout a wave to all devices in the "us-east" device group:
+Rollout a Wave to all devices in the "us-east" device group:
 $ fioctl waves rollout --group us-east
 
-Rollout a wave to 10 devices in the "us-east" device group:
+Rollout a Wave to 10 devices in the "us-east" device group:
 $ fioctl waves rollout --group us-east --limit=10
 
-Rollout a wave to 2 specific devices in the "us-east" device group:
+Rollout a Wave to 2 specific devices in the "us-east" device group:
 $ fioctl waves rollout --group us-east --uuids=uuid1,uuid2
 
-Rollout a wave to 10% devices in your factory:
+Rollout a Wave to 10% devices in your Factory:
 $ fioctl waves rollout --limit=10%
 
-Rollout a wave to specific devices in your factory, device UUIDs provided by a file:
+Rollout a Wave to specific devices in your Factory, device UUIDs provided by a file:
 $ fioctl waves rollout --uuids=@/path/to/file
 
-Rollout a wave to 10% of specific devices in your factory, device UUIDs provided by a file:
+Rollout a Wave to 10% of specific devices in your Factory, device UUIDs provided by a file:
 $ fioctl waves rollout --uuids=@/path/to/file --limit=10%
 
 In all of the above examples:
-- When using the "uuids" flag, each device in a list is verified to match wave requirements.
+- When using the "uuids" flag, each device in a list is verified to match Wave requirements.
   In addition, if the "group" flag is provided, each device must also belong to that device group.
 - When using the "limit" flag, a list of rolled out devices is auto-selected by the API.
   The most recently active devices have a higher chance to get into this selection.
-  A device is excluded from the selection, if a wave was already rolled out to it earlier.
+  A device is excluded from the selection, if a Wave was already rolled out to it earlier.
 - Using both "uuids" and "limit" flags constrains auto-selection to a given device list.
   This can be combined with the "group" flag to further constrain it to a given device group.
 - The following characters are supported as a separator for the device list in the "uuids" flag:
@@ -77,9 +77,9 @@ A maximum number of devices rolled out using this flag cannot exceed 10000.`,
 	rollout.Flags().BoolP("dry-run", "", false,
 		"Only show what would happen without an actual rollout. Most useful with --print-xxx flags.")
 	rollout.Flags().BoolP("print-uuids", "", false,
-		"Print UUIDs of devices to which a wave was rolled out (would be rolled out with --dry-run).")
+		"Print UUIDs of devices to which a Wave was rolled out (would be rolled out with --dry-run).")
 	rollout.Flags().BoolP("print-names", "", false,
-		"Print names of devices to which a wave was rolled out (would be rolled out with --dry-run).")
+		"Print names of devices to which a Wave was rolled out (would be rolled out with --dry-run).")
 	cmd.AddCommand(rollout)
 }
 
@@ -102,7 +102,7 @@ func doRolloutWave(cmd *cobra.Command, args []string) {
 	}
 
 	selector := getDebugSelector(group, uuids, limit, percentage)
-	logrus.Debugf("Rolling out a wave %s for %s to %s", wave, factory, selector)
+	logrus.Debugf("Rolling out Wave %s for %s to %s", wave, factory, selector)
 
 	options := client.WaveRolloutOptions{
 		Group:      group,
@@ -118,18 +118,18 @@ func doRolloutWave(cmd *cobra.Command, args []string) {
 
 	if len(group) == 0 {
 		if dryRun {
-			fmt.Printf("A wave would be rolled out to %d devices in your factory.\n", res.DeviceNum)
+			fmt.Printf("A Wave would be rolled out to %d devices in your Factory.\n", res.DeviceNum)
 		} else {
-			fmt.Printf("A wave is being rolled out to %d devices in your factory.\n", res.DeviceNum)
+			fmt.Printf("A Wave is being rolled out to %d devices in your Factory.\n", res.DeviceNum)
 		}
 	} else {
 		if dryRun {
-			fmt.Printf("A wave would be rolled out to %d devices in group \"%s\".\n", res.DeviceNum, group)
+			fmt.Printf("A Wave would be rolled out to %d devices in group \"%s\".\n", res.DeviceNum, group)
 			if isFullRollout {
 				fmt.Printf("It would also be rolled out to all new devices in group \"%s\".\n", group)
 			}
 		} else {
-			fmt.Printf("A wave is being rolled out to %d devices in group \"%s\".\n", res.DeviceNum, group)
+			fmt.Printf("A Wave is being rolled out to %d devices in group \"%s\".\n", res.DeviceNum, group)
 			if isFullRollout {
 				fmt.Printf("It will also be rolled out to all new devices in group \"%s\".\n", group)
 			}

--- a/subcommands/waves/show.go
+++ b/subcommands/waves/show.go
@@ -18,14 +18,14 @@ func init() {
 		Args:  cobra.ExactArgs(1),
 	}
 	cmd.AddCommand(showCmd)
-	showCmd.Flags().BoolP("show-targets", "s", false, "Show wave targets")
+	showCmd.Flags().BoolP("show-targets", "s", false, "Show Wave Targets")
 }
 
 func doShowWave(cmd *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
 	name := args[0]
 	showTargets, _ := cmd.Flags().GetBool("show-targets")
-	logrus.Debugf("Showing a wave %s for %s", name, factory)
+	logrus.Debugf("Showing Wave %s for %s", name, factory)
 
 	wave, err := api.FactoryGetWave(factory, name, showTargets)
 	subcommands.DieNotNil(err)
@@ -51,7 +51,7 @@ func doShowWave(cmd *cobra.Command, args []string) {
 			}
 
 			if rollout.IsFactoryWide {
-				line += fmt.Sprintf("%d devices in factory", rollout.DeviceNumber)
+				line += fmt.Sprintf("%d devices in Factory", rollout.DeviceNumber)
 			} else if rollout.IsFullGroup {
 				line += fmt.Sprintf("all devices in group %s", groupName)
 			} else {

--- a/subcommands/waves/sign.go
+++ b/subcommands/waves/sign.go
@@ -12,16 +12,16 @@ import (
 func init() {
 	signCmd := &cobra.Command{
 		Use:   "sign <wave>",
-		Short: "Sign an existing wave targets with additional key",
-		Long: `Sign an existing wave targets with additional key.
+		Short: "Sign existing Wave Targets with additional key",
+		Long: `Sign existing Wave Targets with additional key.
 
-This command is only needed when your TUF root requires more than 1 signature for production targets.
+This command is only needed when your TUF root requires more than 1 signature for production Targets.
 In this case, you cannot roll out or complete a wave before it has enough signatures.`,
 		Run:  doSignWave,
 		Args: cobra.ExactArgs(1),
 	}
 	cmd.AddCommand(signCmd)
-	signCmd.Flags().StringP("keys", "k", "", "Path to <offline-creds.tgz> used to sign wave targets.")
+	signCmd.Flags().StringP("keys", "k", "", "Path to <offline-creds.tgz> used to sign wave Targets.")
 	_ = signCmd.MarkFlagRequired("keys")
 }
 

--- a/subcommands/waves/status.go
+++ b/subcommands/waves/status.go
@@ -14,40 +14,40 @@ import (
 func init() {
 	showCmd := &cobra.Command{
 		Use:   "status [<wave>]",
-		Short: "Show a status for a given wave by name",
-		Long: `Show a status for a given wave by name.
-When no wave name is provided - show a status for a currently active wave.
+		Short: "Show status for a given Wave by name",
+		Long: `Show status for a given Wave by name.
+When no Wave name is provided — show a status for a currently active Wave.
 
-For an active wave this command shows an overview of a wave,
-followed by an overview of device groups participating in a wave,
-and after that a detailed information for each rollout group.
+For an active Wave, this command shows an overview if it,
+followed by an overview of device groups participating in the Wave,
+and lastly, detailed information for each rollout group.
 
-For finished waves a detailed per group information is not shown as it is no more relevant.
+For finished Waves, detailed per group information is not shown as it is no longer relevant.
 
-When counting a total number of devices participating in a wave,
-each production device that has a tag equal to a wave tag counts.
+When counting the total number of devices participating in a Wave,
+each production device with a tag equal to a Wave tag counts.
 In particular, devices outside rollout groups also count if they satisfy this condition.
 
 All other numbers are calculated relative to this total number.
-For example, online devices in each group are counted among only those production devices,
+For example, online devices in each group are counted only among those production devices
 that belong to a given group and also have a tag equal to a group tag.
-This number can be lower than a total number of online devices in this group.
+This number can be lower than the total number of online devices in this group.
 
-In a device group overview all wave rollout groups are shown first in an order of rollout time.
-After that follow other groups that have devices with matching tag (if they contain at least one such device).
-The last row is for devices not belonging to any group (if at least one such device matches a wave tag).
+In a device group overview, all Wave rollout groups are shown first in the order of rollout time.
+Next is other groups that have devices with a matching tag — if they contain at least one such device.
+The last row is for devices not belonging to any group — if at least one such device matches a Wave tag.
 
-A number of updated devices depends onto a wave status:
-For active wave it is a number of devices in rollout groups with target version >= wave version.
-For finished waves it is a number of all devices with target version >= wave version.
+A number of updated devices depends onto a Wave status:
+For active Waves, it is a number of devices in rollout groups with Target version >= Wave version.
+For finished Waves, it is a number of all devices with Target version >= Wave version.
 
-Meaning of scheduled vs unscheduled (for update) device number also depends onto a wave status:
-For active wave, scheduled for update are devices in rollout groups with target version < wave version.
-For complete wave, scheduled are all devices (regardless a group) with target version < wave version.
-For canceled wave, all devices with target version < wave version are unscheduled (scheduled is always zero).
+Meaning of scheduled vs unscheduled (for updates) device number also depends on Wave status:
+For an active Wave, "scheduled for update" are devices in rollout groups with Target version < Wave version.
+For a completed Wave, "scheduled" are all devices (regardless of group) with Target version < Wave version.
+For a canceled Wave, all devices with Target version < Wave version are unscheduled (scheduled is always zero).
 
-For finished waves all numbers are calculated for a current date (not a date of a wave finishing).
-This can be used to monitor how an update progresses after a wave has been complete.
+For finished Waves, all numbers are calculated for a current date (not a date of a Wave finishing).
+This can be used to monitor how an update progresses after a Wave completes.
 `,
 		Run:  doShowWaveStatus,
 		Args: cobra.RangeArgs(0, 1),
@@ -62,9 +62,9 @@ func doShowWaveStatus(cmd *cobra.Command, args []string) {
 	name := "$active$"
 	if len(args) > 0 {
 		name = args[0]
-		logrus.Debugf("Showing a wave %s status for %s", name, factory)
+		logrus.Debugf("Showing Wave %s status for %s", name, factory)
 	} else {
-		logrus.Debugf("Showing an active wave status for %s", factory)
+		logrus.Debugf("Showing active Wave status for %s", factory)
 	}
 
 	status, err := api.FactoryWaveStatus(factory, name, offlineThreshold)
@@ -74,7 +74,7 @@ func doShowWaveStatus(cmd *cobra.Command, args []string) {
 		status.Name, status.Tag, status.Version, status.Status)
 	fmt.Println()
 	if status.Status != "active" {
-		fmt.Println("A device information is shown for a current time, not for a time when a wave was finished")
+		fmt.Println("Device information is shown for the current time, not for when a Wave finished")
 		fmt.Println()
 	}
 	fmt.Printf("Created At: \t%s\n", status.CreatedAt)
@@ -123,8 +123,8 @@ func doShowWaveStatus(cmd *cobra.Command, args []string) {
 	}
 
 	if hasTargets && status.Status == "active" {
-		fmt.Println("\nOrphan target versions below are marked with a star (*)")
-		fmt.Println("Wave target version below is marked with an arrow (<-)")
+		fmt.Println("\nOrphan Target versions below are marked with a star (*)")
+		fmt.Println("Wave Target version below is marked with an arrow (<-)")
 		for _, group := range status.RolloutGroups {
 			showGroupStatusTargets(group, status)
 		}
@@ -147,7 +147,7 @@ func showGroupStatusTargets(group client.RolloutGroupStatus, status *client.Wave
 			mark = "*"
 		}
 		if tgt.Version > 0 {
-			details = fmt.Sprintf("`fioctl targets show %d`", tgt.Version)
+			details = fmt.Sprintf("`fioctl Targets show %d`", tgt.Version)
 		}
 		t.AddLine(fmt.Sprintf("%-6d%2s", tgt.Version, mark), tgt.Devices, details)
 	}

--- a/x509/bash.go
+++ b/x509/bash.go
@@ -46,7 +46,7 @@ func run(script string, arg ...string) string {
 func CreateFactoryCa(ou string) string {
 	const script = `#!/bin/sh -e
 ## This script creates the offline private key, factory_ca.key, and x509 certficate, factory_ca.pem,
-## owned by the customer that provides a chain of trust for all other certficates used by this factory.
+## owned by the user that provides a chain of trust for all other certficates used by this Factory.
 
 if [ $# -ne 1 ] ; then
 	echo "ERROR: $0 <ou>"
@@ -101,10 +101,10 @@ func CreateDeviceCa(cn, ou string) string {
 
 func CreateDeviceCaExt(cn, ou, keyFile, certFile string) string {
 	const script = `#!/bin/sh -e
-## This is an optional script a customer can use to create a certificate
-## capable of signing a certicate signing request from an LMP device.
-## The certicate created here will be trusted by the Foundries device gateway.
-## This is useful for creating CA owned by the customer for use in a manufacturing facility.
+## This is an optional script used to create a certificate
+## capable of signing a certicate signing request from an LmP device.
+## The certicate created here will be trusted by the Foundries.io device gateway.
+## This is useful for creating CA owned by the user for use in a manufacturing facility.
 
 if [ $# -ne 3 ] ; then
 	echo "ERROR: $0 <key-create> <cn> <ou>"
@@ -169,7 +169,7 @@ func CreateCrl(serials map[string]int) string {
 func signTlsCsr(tmpFileMask, csrPem string) string {
 	const script = `#!/bin/sh -e
 ## This script signs the "tls-csr" returned when creating Factory certificates.
-## This certificate are signed so that the devices trust the TLS connection with the Foundries device gateway.
+## These certificates are signed so that the devices trust the TLS connection with the Foundries.io device gateway.
 
 if [ $# -ne 2 ] ; then
 	echo "ERROR: $0 <tls csr> <tls crt>"


### PR DESCRIPTION
This is part 2 of 2 of the effort to cleanup the text for help commands and logging. Mostly minor changes made so as to align with style-guide, or in a effort to increase readability.

This commit addresses FFTK-2391, "Fix Fioctl style and typos"