### PR TITLE
fix(git): expand user home dir first

### DIFF
--- a/subcommands/docker/cmd.go
+++ b/subcommands/docker/cmd.go
@@ -122,6 +122,9 @@ func doDockerCreds(cmd *cobra.Command, args []string) {
 	configBytes, err := subcommands.MarshalIndent(config, "", "  ")
 	subcommands.DieNotNil(err)
 
+	if strings.Contains(helperPath, "~/") {
+		subcommands.DieNotNil(fmt.Errorf("~ character is not supported in --creds-path=. Try to run it as --creds-path %s", helperPath))
+	}
 	dst := filepath.Join(helperPath, DOCKER_CREDS_HELPER)
 	if runtime.GOOS == "windows" {
 		dst += ".exe"

--- a/subcommands/git/cmd.go
+++ b/subcommands/git/cmd.go
@@ -19,9 +19,7 @@ import (
 
 const GIT_CREDS_HELPER = "git-credential-fio"
 
-var (
-	helperPath string
-)
+var helperPath string
 
 func NewCommand() *cobra.Command {
 	path, err := exec.LookPath("git")
@@ -74,6 +72,9 @@ func doGitCreds(cmd *cobra.Command, args []string) {
 	var gitHelperCommandArgs []string
 
 	helperName := "fio"
+	if strings.Contains(helperPath, "~/") {
+		subcommands.DieNotNil(fmt.Errorf("~ character is not supported in --creds-path=. Try to run it as --creds-path %s", helperPath))
+	}
 	dst := filepath.Join(helperPath, GIT_CREDS_HELPER)
 	if runtime.GOOS == "windows" {
 		// To get around edge cases with git on Windows we use the absolute path


### PR DESCRIPTION
When using it like `fioctl configure-git --creds-path ~/.config` there is no problem however if you use it like `fioctl configure-git --creds-path=~/.config` there is.

The reason lies in the fact that in the first example the shell already expands the ~ into the absolute path of the homedir, in the second it will not.