### PR TITLE
targets: Add missing fields to TufCustom

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -141,6 +141,8 @@ type TufCustom struct {
 	UpdatedAt      string                `json:"updatedAt,omitempty"`
 	LmpVer         string                `json:"lmp-ver,omitempty"`
 	FetchedApps    *FetchedApps          `json:"fetched-apps,omitempty"`
+	Arch           string                `json:"arch,omitempty"`
+	ImageFile      string                `json:"image-file,omitempty"`
 }
 
 type Target struct {


### PR DESCRIPTION
The `fioctl targets add` command must retain the arch and image-file custom fields from the previous target. Otherwise, the publish-compose-apps operation for new targets will fail.

This commit adds both field to the structure used in the process, allowing the required fields to be copied to the target being added.

---

@mike-sul after some additional tests with targets creation, it is clear that this change is in fact required.