### PR TITLE
targets: Handle OrigUri and OrigUriApps when adding targets

### DIFF
--- a/client/foundries.go
+++ b/client/foundries.go
@@ -137,6 +137,7 @@ type TufCustom struct {
 	OverridesSha   string                `json:"meta-subscriber-overrides-sha,omitempty"`
 	Uri            string                `json:"uri,omitempty"`
 	OrigUri        string                `json:"origUri,omitempty"`
+	OrigUriApps    string                `json:"origUriApps,omitempty"`
 	CreatedAt      string                `json:"createdAt,omitempty"`
 	UpdatedAt      string                `json:"updatedAt,omitempty"`
 	LmpVer         string                `json:"lmp-ver,omitempty"`

--- a/subcommands/targets/add.go
+++ b/subcommands/targets/add.go
@@ -107,6 +107,11 @@ func createAppTargets(factory string, tags []string, srcTag string, appUris []st
 	return deriveTargets(factory, nil, srcTag, func(target *client.Target) error {
 		target.Custom.Tags = tags
 		target.Custom.ComposeApps = newTargetApps
+		if target.Custom.OrigUri == "" {
+			target.Custom.OrigUri = target.Custom.Uri
+		}
+		target.Custom.Uri = ""
+		target.Custom.OrigUriApps = ""
 		return nil
 	})
 }
@@ -134,6 +139,11 @@ func createOstreeTarget(factory string, tags []string, srcTag string, hwIdToHash
 	return deriveTargets(factory, hwIdToHash, srcTag, func(target *client.Target) error {
 		target.Custom.Tags = tags
 		err := target.SetHash(hwIdToHash[target.HardwareId()].(string))
+		if target.Custom.OrigUriApps == "" {
+			target.Custom.OrigUriApps = target.Custom.Uri
+		}
+		target.Custom.Uri = ""
+		target.Custom.OrigUri = ""
 		return err
 	})
 }


### PR DESCRIPTION
For custom apps targets, origUri must be set, while uri and origUriApps must be empty.
For custom ostree targets, origUriApps must be set, while uri and origUri must be empty.

---
@mike-sul this change seems to work, but is not enough. Apps targets generated by our CI are keeping the `origUriApps` field set. I'd say we need to fix the behavior there before merging this change to fioctl. Otherwise, an old `origUriApps` value is carried on indefinitely.