### PR TITLE
Fixes to the git credential helper

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,6 +82,7 @@ func init() {
 	rootCmd.AddCommand(devices.NewCommand())
 	rootCmd.AddCommand(docker.NewCommand())
 	rootCmd.AddCommand(git.NewCommand())
+	rootCmd.AddCommand(git.NewGetCredsCommand())
 	rootCmd.AddCommand(events.NewCommand())
 	rootCmd.AddCommand(factories.NewCommand())
 	rootCmd.AddCommand(keys.NewCommand())

--- a/subcommands/git/cmd.go
+++ b/subcommands/git/cmd.go
@@ -84,6 +84,9 @@ func doGitCreds(cmd *cobra.Command, args []string) {
 	}
 
 	apiUrl := viper.GetString("server.url")
+	if len(apiUrl) == 0 {
+		apiUrl = "https://api.foundries.io"
+	}
 	parts, err := url.Parse(apiUrl)
 	subcommands.DieNotNil(err)
 	sourceUrl := strings.Replace(parts.Host, "api.", "source.", 1)

--- a/subcommands/git/cmd.go
+++ b/subcommands/git/cmd.go
@@ -50,6 +50,21 @@ NOTE: The credentials will need the "source:read-update" scope to work with Git`
 	return cmd
 }
 
+func NewGetCredsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "git-credential-helper",
+		Hidden: true, // its used as a git-credential helper and is not user facing
+		Args:   cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if args[0] != "get" {
+				subcommands.DieNotNil(fmt.Errorf("This credential helper only supports 'get' and not '%s'", args[0]))
+			}
+			os.Exit(RunCredsHelper())
+		},
+	}
+	return cmd
+}
+
 func findSelf() string {
 	self := os.Args[0]
 	if !filepath.IsAbs(self) {


### PR DESCRIPTION
This set of changes fixes some rough edges with our git credential helper.

The first change fixes something that "works" but was reckless where we accidentally configured our helper for all "https:*" URLs.

The last 2 changes address the complexity we've had trying to reliably make a symlink from "fioctl -> git-credential-fio". It turns out we never needed to do that and could have gone with a simpler approach that has less ways to fail.