### PR TITLE
chore(actions): update to v4 for artifacts

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -20,7 +20,7 @@ jobs:
         run: make build
 
       - name: Archive Binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries
           path: bin/
@@ -51,7 +51,7 @@ jobs:
           platforms: ${{ matrix.qemu-platform }}
 
       - name: Download Binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binaries
           path: bin/
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binaries
           path: bin/


### PR DESCRIPTION
This should fix our deprecated GitHub action workflow actions. 