### PR TITLE
fix(root): allow empty args for autocomplete

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,6 +104,9 @@ func init() {
 }
 
 func rootArgValidation(cmd *cobra.Command, args []string) error {
+	if strings.HasPrefix(cmd.Name(), "__complete") {
+		return nil
+	}
 	for pos, val := range args {
 		if len(strings.TrimSpace(val)) == 0 {
 			return fmt.Errorf("Empty values or values containing only white space are not allowed for positional argument at %d\n", pos)


### PR DESCRIPTION
The completion command fails now on `fish` because when you run `fioctl ` and then hit `<Tab>` then the auto complete will fail because we will always return an error, which leads to not seeing all the options possible.