### PR TITLE
release: Fix permission required for pushing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ name: Create release
 jobs:
   build:
     name: Build and publish
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
The move to Github Enterprise seems to require this.