### PR TITLE
Add `devices tests` subcommand

### DIFF
--- a/client/foundries_device.go
+++ b/client/foundries_device.go
@@ -397,3 +397,31 @@ func (d *DeviceApi) GetAppsStates() (*AppsStates, error) {
 	}
 	return &states, nil
 }
+
+func (d *DeviceApi) Tests() (*TargetTestList, error) {
+	url := d.url("/tests/")
+	logrus.Debugf("Device.Tests with url: %s", url)
+	return d.api.TargetTestsCont(url)
+}
+
+func (d *DeviceApi) TestGet(testId string) (*TargetTest, error) {
+	url := d.url("/tests/" + testId)
+	logrus.Debugf("DeviceTriggerResults with url: %s", url)
+	body, err := d.api.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	test := TargetTest{}
+	err = json.Unmarshal(*body, &test)
+	if err != nil {
+		return nil, err
+	}
+	return &test, nil
+}
+
+func (d *DeviceApi) TestResultArtifact(testId, artifact string) (*[]byte, error) {
+	url := d.url("/tests/" + testId + "/" + artifact)
+	logrus.Debugf("DeviceTriggerResults with url: %s", url)
+	return d.api.Get(url)
+}

--- a/client/foundries_device.go
+++ b/client/foundries_device.go
@@ -401,7 +401,8 @@ func (d *DeviceApi) GetAppsStates() (*AppsStates, error) {
 func (d *DeviceApi) Tests() (*TargetTestList, error) {
 	url := d.url("/tests/")
 	logrus.Debugf("Device.Tests with url: %s", url)
-	return d.api.TargetTestsCont(url)
+	ttl := TargetTestList{api: *d.api, Next: &url}
+	return ttl.NextPage()
 }
 
 func (d *DeviceApi) TestGet(testId string) (*TargetTest, error) {

--- a/client/foundries_fiotest.go
+++ b/client/foundries_fiotest.go
@@ -32,12 +32,21 @@ type TargetTestList struct {
 	Next  *string      `json:"next"`
 }
 
+type TargetTestingApi struct {
+	api     Api
+	factory string
+}
+
+func (a Api) TargetTestingApi(factory string) TargetTestingApi {
+	return TargetTestingApi{api: a, factory: factory}
+}
+
 // Return a list of Targets that have been tested
-func (a *Api) TargetTesting(factory string) ([]int, error) {
-	url := a.serverUrl + "/ota/factories/" + factory + "/testing/"
+func (a TargetTestingApi) Versions() ([]int, error) {
+	url := a.api.serverUrl + "/ota/factories/" + a.factory + "/testing/"
 	logrus.Debugf("TargetTesting with url: %s", url)
 
-	body, err := a.Get(url)
+	body, err := a.api.Get(url)
 	if err != nil {
 		return nil, err
 	}
@@ -52,13 +61,13 @@ func (a *Api) TargetTesting(factory string) ([]int, error) {
 	return r.Versions, nil
 }
 
-func (a *Api) TargetTests(factory string, target int) (*TargetTestList, error) {
-	url := a.serverUrl + "/ota/factories/" + factory + "/targets/" + strconv.Itoa(target) + "/testing/"
+func (a TargetTestingApi) Tests(target int) (*TargetTestList, error) {
+	url := a.api.serverUrl + "/ota/factories/" + a.factory + "/targets/" + strconv.Itoa(target) + "/testing/"
 	logrus.Debugf("TargetTests with url: %s", url)
-	return a.TargetTestsCont(url)
+	return a.api.TargetTestsCont(url)
 }
 
-func (a *Api) TargetTestsCont(url string) (*TargetTestList, error) {
+func (a Api) TargetTestsCont(url string) (*TargetTestList, error) {
 	body, err := a.Get(url)
 	if err != nil {
 		return nil, err
@@ -72,10 +81,10 @@ func (a *Api) TargetTestsCont(url string) (*TargetTestList, error) {
 	return &tests, nil
 }
 
-func (a *Api) TargetTestResults(factory string, target int, testId string) (*TargetTest, error) {
-	url := a.serverUrl + "/ota/factories/" + factory + "/targets/" + strconv.Itoa(target) + "/testing/" + testId + "/"
+func (a TargetTestingApi) TestResults(target int, testId string) (*TargetTest, error) {
+	url := a.api.serverUrl + "/ota/factories/" + a.factory + "/targets/" + strconv.Itoa(target) + "/testing/" + testId + "/"
 	logrus.Debugf("TargetTests with url: %s", url)
-	body, err := a.Get(url)
+	body, err := a.api.Get(url)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +97,8 @@ func (a *Api) TargetTestResults(factory string, target int, testId string) (*Tar
 	return &test, nil
 }
 
-func (a *Api) TargetTestArtifact(factory string, target int, testId string, artifact string) (*[]byte, error) {
-	url := a.serverUrl + "/ota/factories/" + factory + "/targets/" + strconv.Itoa(target) + "/testing/" + testId + "/" + artifact
+func (a TargetTestingApi) TestArtifact(target int, testId string, artifact string) (*[]byte, error) {
+	url := a.api.serverUrl + "/ota/factories/" + a.factory + "/targets/" + strconv.Itoa(target) + "/testing/" + testId + "/" + artifact
 	logrus.Debugf("TargetTests with url: %s", url)
-	return a.Get(url)
+	return a.api.Get(url)
 }

--- a/subcommands/devices/tests.go
+++ b/subcommands/devices/tests.go
@@ -1,0 +1,119 @@
+package devices
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cheynewallace/tabby"
+	"github.com/spf13/cobra"
+
+	"github.com/foundriesio/fioctl/client"
+	"github.com/foundriesio/fioctl/subcommands"
+)
+
+func init() {
+	logsCmd := &cobra.Command{
+		Use:   "tests <device> [<test id> [<artifact name>]]",
+		Short: "List tests results uploaded by a device",
+		Run:   doTests,
+		Args:  cobra.RangeArgs(1, 3),
+	}
+	cmd.AddCommand(logsCmd)
+}
+
+func timestamp(ts float32) string {
+	if ts == 0 {
+		return ""
+	}
+	secs := int64(ts)
+	nsecs := int64((ts - float32(secs)) * 1e9)
+	return time.Unix(secs, nsecs).UTC().String()
+}
+
+func doTests(cmd *cobra.Command, args []string) {
+	switch len(args) {
+	case 1:
+		doTestList(cmd, args)
+	case 2:
+		doTestShow(cmd, args)
+	case 3:
+		doTestArtifact(cmd, args)
+	default:
+		panic("invalid number of args") // "impossible" because of cobra.RangeArgs
+	}
+}
+
+func doTestList(cmd *cobra.Command, args []string) {
+	name := args[0]
+	d := getDevice(cmd, name)
+
+	t := tabby.New()
+	t.AddHeader("NAME", "STATUS", "ID", "CREATED AT")
+
+	var tl *client.TargetTestList
+	for {
+		var err error
+		if tl == nil {
+			tl, err = d.Api.Tests()
+		} else {
+			if tl.Next != nil {
+				tl, err = api.TargetTestsCont(*tl.Next)
+			} else {
+				break
+			}
+		}
+		subcommands.DieNotNil(err)
+		for _, test := range tl.Tests {
+			created := timestamp(test.CreatedOn)
+			t.AddLine(test.Name, test.Status, test.Id, created)
+		}
+	}
+	t.Print()
+}
+
+func doTestShow(cmd *cobra.Command, args []string) {
+	name := args[0]
+	testId := args[1]
+	d := getDevice(cmd, name)
+
+	result, err := d.Api.TestGet(testId)
+	subcommands.DieNotNil(err)
+
+	fmt.Println("Name:     ", result.Name)
+	fmt.Println("Status:   ", result.Status)
+	fmt.Println("Created:  ", timestamp(result.CreatedOn))
+	fmt.Println("Completed:", timestamp(result.CompletedOn))
+
+	if len(result.Details) > 0 {
+		fmt.Println("Details:")
+		fmt.Println(result.Details)
+	}
+
+	if len(result.Artifacts) > 0 {
+		fmt.Println("Artifacts:")
+		for _, a := range result.Artifacts {
+			fmt.Println("\t", a)
+		}
+	}
+	if len(result.Results) > 0 {
+		fmt.Println("")
+		t := tabby.New()
+		t.AddHeader("TEST RESULT", "STATUS")
+		for _, result := range result.Results {
+			t.AddLine(result.Name, result.Status)
+		}
+		t.Print()
+	}
+}
+
+func doTestArtifact(cmd *cobra.Command, args []string) {
+	name := args[0]
+	testId := args[1]
+	artifact := args[2]
+	d := getDevice(cmd, name)
+
+	content, err := d.Api.TestResultArtifact(testId, artifact)
+	subcommands.DieNotNil(err)
+	os.Stdout.Write(*content)
+}

--- a/subcommands/devices/tests.go
+++ b/subcommands/devices/tests.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cheynewallace/tabby"
 	"github.com/spf13/cobra"
 
-	"github.com/foundriesio/fioctl/client"
 	"github.com/foundriesio/fioctl/subcommands"
 )
 
@@ -51,23 +50,15 @@ func doTestList(cmd *cobra.Command, args []string) {
 	t := tabby.New()
 	t.AddHeader("NAME", "STATUS", "ID", "CREATED AT")
 
-	var tl *client.TargetTestList
-	for {
-		var err error
-		if tl == nil {
-			tl, err = d.Api.Tests()
-		} else {
-			if tl.Next != nil {
-				tl, err = api.TargetTestsCont(*tl.Next)
-			} else {
-				break
-			}
-		}
-		subcommands.DieNotNil(err)
+	tl, err := d.Api.Tests()
+	subcommands.DieNotNil(err)
+	for tl != nil {
 		for _, test := range tl.Tests {
 			created := timestamp(test.CreatedOn)
 			t.AddLine(test.Name, test.Status, test.Id, created)
 		}
+		tl, err = tl.NextPage()
+		subcommands.DieNotNil(err)
 	}
 	t.Print()
 }

--- a/subcommands/targets/tests.go
+++ b/subcommands/targets/tests.go
@@ -47,7 +47,7 @@ func timestamp(ts float32) string {
 }
 
 func listAll(factory string) {
-	versions, err := api.TargetTesting(factory)
+	versions, err := api.TargetTestingApi(factory).Versions()
 	subcommands.DieNotNil(err)
 	fmt.Println("Tested Targets:")
 	for _, ver := range versions {
@@ -56,6 +56,7 @@ func listAll(factory string) {
 }
 
 func list(factory string, target int) {
+	tapi := api.TargetTestingApi(factory)
 	t := tabby.New()
 	t.AddHeader("NAME", "STATUS", "ID", "CREATED AT", "DEVICE")
 
@@ -63,7 +64,7 @@ func list(factory string, target int) {
 	for {
 		var err error
 		if tl == nil {
-			tl, err = api.TargetTests(factory, target)
+			tl, err = tapi.Tests(target)
 		} else {
 			if tl.Next != nil {
 				tl, err = api.TargetTestsCont(*tl.Next)
@@ -85,7 +86,7 @@ func list(factory string, target int) {
 }
 
 func show(factory string, target int, testId string) {
-	test, err := api.TargetTestResults(factory, target, testId)
+	test, err := api.TargetTestingApi(factory).TestResults(target, testId)
 	subcommands.DieNotNil(err)
 	fmt.Println("Name:     ", test.Name)
 	fmt.Println("Status:   ", test.Status)
@@ -140,7 +141,7 @@ func doShowTests(cmd *cobra.Command, args []string) {
 		testId := args[1]
 		artifact := args[2]
 		logrus.Debugf("Showing Target test artifacts for %s %d - %s / %s", factory, target, testId, artifact)
-		content, err := api.TargetTestArtifact(factory, target, testId, artifact)
+		content, err := api.TargetTestingApi(factory).TestArtifact(target, testId, artifact)
 		subcommands.DieNotNil(err)
 		os.Stdout.Write(*content)
 	}


### PR DESCRIPTION
This compliments the recent API change to support looking up test results by Device rather than Target.