### PR TITLE
devices updates: Fix `by-uuuid-flag` warning

### DIFF
--- a/subcommands/devices/updates_show.go
+++ b/subcommands/devices/updates_show.go
@@ -11,17 +11,7 @@ import (
 	"github.com/foundriesio/fioctl/subcommands"
 )
 
-func init() {
-	updatesCmd.AddCommand(&cobra.Command{
-		Use:    "show <name> <update-id>",
-		Short:  "[DEPRECATED] Please use: fioctl devices updates <device> <update-id>",
-		Hidden: true,
-		Run:    doShowUpdate,
-		Args:   cobra.ExactArgs(2),
-	})
-}
-
-func doShowUpdate(cmd *cobra.Command, args []string) {
+func doShowUpdate(_ *cobra.Command, args []string) {
 	factory := viper.GetString("factory")
 	logrus.Debug("Showing device update")
 	d := api.DeviceApiByName(factory, args[0])


### PR DESCRIPTION
We tried adding support for `-by-uuid` to all device subcommands:
  https://github.com/foundriesio/fioctl/commit/89be418dfcded2565a7357c92453fb8840b85ab5

However, the logic in `addUuidFlagToChildren` only adds the flag to commands that have subcommands. The `updates` command does not have any which causes us to print a warning each time you run the command:
```
ERROR: flag accessed but not defined: by-uuid
```

This causes a small bit of duplication, but seems to be the easiest way to fix this issue.